### PR TITLE
Fix occasional JSMPEG rendering bug

### DIFF
--- a/src/components/live.ts
+++ b/src/components/live.ts
@@ -202,15 +202,6 @@ export class FrigateCardViewerJSMPEG extends LitElement {
     return url.replace(/^http/i, 'ws');
   }
 
-  disconnectedCallback(): void {
-    if (this._jsmpegVideoPlayer) {
-      this._jsmpegVideoPlayer.destroy();
-      this._jsmpegVideoPlayer = null;
-    }
-    this._jsmpegCanvasElement = null;
-    super.disconnectedCallback();
-  }
-
   protected render(): TemplateResult | void {
     return html`${until(this._render(), renderProgressIndicator())}`;
   }


### PR DESCRIPTION
* Don't destroy the player on node disconnection, as it may be reconnected (without re-rendering).
* Closes #108 