### PR TITLE
Extend the default expiry of the signed JSMPEG URL

### DIFF
--- a/src/components/live.ts
+++ b/src/components/live.ts
@@ -180,6 +180,7 @@ export class FrigateCardLiveJSMPEG extends LitElement {
     const request = {
       type: 'auth/sign_path',
       path: `/api/frigate/${this.clientId}` + `/jsmpeg/${this.cameraName}`,
+      expires: 60 * 15,
     };
     // Sign the path so it includes an authSig parameter.
     let response;


### PR DESCRIPTION
* Experimental fix for what some users report in #109 