### PR TITLE
fix: Fix double tap on iOS devices

### DIFF
--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -30,7 +30,7 @@ class ActionHandler extends HTMLElement implements ActionHandlerInterface {
 
   protected holdTimer = new Timer();
   protected doubleClickTimer = new Timer();
-
+  private cancelled = false;
   protected held = false;
   protected started = false;
 
@@ -47,6 +47,7 @@ class ActionHandler extends HTMLElement implements ActionHandlerInterface {
       document.addEventListener(
         ev,
         () => {
+          this.cancelled = true;
           this.holdTimer.stop();
         },
         { passive: true },
@@ -79,6 +80,7 @@ class ActionHandler extends HTMLElement implements ActionHandlerInterface {
     });
 
     const start = (): void => {
+      this.cancelled = false;
       this.held = false;
       this.holdTimer.start(this.holdTime, () => {
         this.held = true;
@@ -110,7 +112,8 @@ class ActionHandler extends HTMLElement implements ActionHandlerInterface {
       }
 
       if (
-        ['touchend', 'touchcancel'].includes(ev.type) &&
+        (ev.type === "touchcancel" ||
+        (ev.type === "touchend" && this.cancelled)) &&
         // This action handler by default relies on synthetic click events for
         // touch devices, in order to ensure that embedded cards (e.g. WebRTC)
         // can use stock click handlers. The exception is for hold events.

--- a/src/action-handler-directive.ts
+++ b/src/action-handler-directive.ts
@@ -112,8 +112,7 @@ class ActionHandler extends HTMLElement implements ActionHandlerInterface {
       }
 
       if (
-        (ev.type === "touchcancel" ||
-        (ev.type === "touchend" && this.cancelled)) &&
+        (ev.type === 'touchcancel' || (ev.type === 'touchend' && this.cancelled)) &&
         // This action handler by default relies on synthetic click events for
         // touch devices, in order to ensure that embedded cards (e.g. WebRTC)
         // can use stock click handlers. The exception is for hold events.


### PR DESCRIPTION
This should fix the issue where iOS devices were unable to get the double tap action working.
Tested on a real iPhone, iOS 18.3.

- Closes #1853 