### PR TITLE
feat: Add support for `config` and `initialized` conditions

### DIFF
--- a/docs/configuration/conditions.md
+++ b/docs/configuration/conditions.md
@@ -30,6 +30,21 @@ conditions:
 | `condition` | Must be `camera`.                                                                                                                                                                     |
 | `cameras`   | An optional list of camera IDs in which this condition is satisfied. If not specified, any camera change will satisy the condition. See the camera [id](cameras/README.md) parameter. |
 
+## `config`
+
+Matches when card configuration changes (e.g. on startup, or when [Configuration Overrides](./overrides.md) are applied).
+
+```yaml
+conditions:
+  - condition: config
+    # [...]
+```
+
+| Parameter   | Description                                                                                                                                           |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `condition` | Must be `config`.                                                                                                                                     |
+| `paths`     | An optional array of configuration paths (e.g. `menu.style`). If provided condition matches if _ANY_ of the provided configuration paths has changed. |
+
 ## `expand`
 
 Matches based on whether the card is in "expanded" mode.
@@ -59,6 +74,21 @@ conditions:
 | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `condition`  | Must be `fullscreen`.                                                                                                                                    |
 | `fullscreen` | If `true` the condition is satisfied if the card is in fullscreen mode. If `false` the condition is satisfied if the card is **NOT** in fullscreen mode. |
+
+## `initialized`
+
+Matches when the card is first initialized.
+
+```yaml
+conditions:
+  - condition: initialized
+```
+
+| Parameter   | Description            |
+| ----------- | ---------------------- |
+| `condition` | Must be `initialized`. |
+
+?> This is exclusively useful for running [automations](./automations.md) on card start.
 
 ## `interaction`
 
@@ -258,10 +288,14 @@ conditions:
  - condition: camera
    cameras:
      - camera.office
+  - condition: config
+    paths:
+      - "menu.style"
   - condition: expand
     expand: true
   - condition: fullscreen
     fullscreen: true
+  - condition: initialized
   - condition: interaction
     interaction: true
   - condition: key

--- a/src/card-controller/config/config-manager.ts
+++ b/src/card-controller/config/config-manager.ts
@@ -184,6 +184,18 @@ export class ConfigManager {
     await this._api.getDefaultManager().initializeIfNecessary(previousConfig);
     await this._api.getMediaPlayerManager().initializeIfNecessary(previousConfig);
 
+    // The config is only set in the state if the card is already fully
+    // initialized. If not, the config will be set post initialization in the
+    // InitializationManager.
+    if (
+      this._overriddenConfig &&
+      this._api.getInitializationManager().isInitializedMandatory()
+    ) {
+      this._api.getConditionStateManager().setState({
+        config: this._overriddenConfig,
+      });
+    }
+
     this._api.getCardElementManager().update();
   }
 }

--- a/src/card-controller/initialization-manager.ts
+++ b/src/card-controller/initialization-manager.ts
@@ -128,6 +128,18 @@ export class InitializationManager {
     }
 
     this._everInitialized = true;
+
+    // When the card is initialized, both the initialization state (will never
+    // change again), and the config are set in the condition state. The
+    // config is set here, rather than in the ConfigManager, in order to
+    // ensure actions (that trigger on config change) are not run before hass
+    // is available and the card is initialzied (the first config is set in
+    // the card *before* hass is set in the card).
+    this._api.getConditionStateManager().setState({
+      config: config,
+      initialized: this._everInitialized,
+    });
+
     this._api.getCardElementManager().update();
   }
 

--- a/src/card-controller/types.ts
+++ b/src/card-controller/types.ts
@@ -176,6 +176,7 @@ export interface CardInitializerAPI {
   getMicrophoneManager(): MicrophoneManager;
 
   getCardElementManager(): CardElementManager;
+  getConditionStateManager(): ConditionStateManager;
   getConfigManager(): ConfigManager;
   getDefaultManager(): DefaultManager;
   getEntityRegistryManager(): EntityRegistryManager;

--- a/src/conditions/types.ts
+++ b/src/conditions/types.ts
@@ -1,14 +1,16 @@
 import { CurrentUser } from '@dermotduffy/custom-card-helpers';
 import { HassEntities } from 'home-assistant-js-websocket';
-import { ViewDisplayMode } from '../config/types';
+import { AdvancedCameraCardConfig, ViewDisplayMode } from '../config/types';
 import { MediaLoadedInfo } from '../types';
 import { KeysState, MicrophoneState } from '../card-controller/types';
 
 export interface ConditionState {
   camera?: string;
+  config?: AdvancedCameraCardConfig;
   displayMode?: ViewDisplayMode;
   expand?: boolean;
   fullscreen?: boolean;
+  initialized?: boolean;
   interaction?: boolean;
   keys?: KeysState;
   mediaLoadedInfo?: MediaLoadedInfo | null;
@@ -43,10 +45,16 @@ interface ConditionsEvaluationDataState extends ConditionsEvaluationDataFromTo {
   entity: string;
 }
 
+interface ConditionsEvaluationDataConfig {
+  from?: AdvancedCameraCardConfig;
+  to?: AdvancedCameraCardConfig;
+}
+
 export interface ConditionsEvaluationData {
   camera?: ConditionsEvaluationDataFromTo;
   view?: ConditionsEvaluationDataFromTo;
   state?: ConditionsEvaluationDataState;
+  config?: ConditionsEvaluationDataConfig;
 }
 export interface ConditionsEvaluationResult {
   result: boolean;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -683,42 +683,32 @@ export type StatusBarItem = z.infer<typeof statusBarItemSchema>;
 //                  Custom Element Configuration: Conditions
 // *************************************************************************
 
-const viewConditionSchema = z.object({
-  condition: z.literal('view'),
-  views: z.string().array().optional(),
-});
-const fullscreenConditionSchema = z.object({
-  condition: z.literal('fullscreen'),
-  fullscreen: z.boolean(),
-});
-const expandConditionSchema = z.object({
-  condition: z.literal('expand'),
-  expand: z.boolean(),
-});
 const cameraConditionSchema = z.object({
   condition: z.literal('camera'),
   cameras: z.string().array().optional(),
 });
-const mediaLoadedConditionSchema = z.object({
-  condition: z.literal('media_loaded'),
-  media_loaded: z.boolean(),
+const configConditionSchema = z.object({
+  condition: z.literal('config'),
+  paths: z.string().array().optional(),
 });
 const displayModeConditionSchema = z.object({
   condition: z.literal('display_mode'),
   display_mode: viewDisplayModeSchema,
 });
-const triggeredConditionSchema = z.object({
-  condition: z.literal('triggered'),
-  triggered: z.string().array(),
+const expandConditionSchema = z.object({
+  condition: z.literal('expand'),
+  expand: z.boolean(),
+});
+const fullscreenConditionSchema = z.object({
+  condition: z.literal('fullscreen'),
+  fullscreen: z.boolean(),
+});
+const initializedConditionSchema = z.object({
+  condition: z.literal('initialized'),
 });
 const interactionConditionSchema = z.object({
   condition: z.literal('interaction'),
   interaction: z.boolean(),
-});
-const microphoneConditionSchema = z.object({
-  condition: z.literal('microphone'),
-  connected: z.boolean().optional(),
-  muted: z.boolean().optional(),
 });
 const keyConditionSchema = z.object({
   condition: z.literal('key'),
@@ -728,6 +718,19 @@ const keyConditionSchema = z.object({
   shift: z.boolean().optional(),
   alt: z.boolean().optional(),
   meta: z.boolean().optional(),
+});
+const mediaLoadedConditionSchema = z.object({
+  condition: z.literal('media_loaded'),
+  media_loaded: z.boolean(),
+});
+const microphoneConditionSchema = z.object({
+  condition: z.literal('microphone'),
+  connected: z.boolean().optional(),
+  muted: z.boolean().optional(),
+});
+const triggeredConditionSchema = z.object({
+  condition: z.literal('triggered'),
+  triggered: z.string().array(),
 });
 const userAgentConditionSchema = z.object({
   condition: z.literal('user_agent'),
@@ -748,26 +751,32 @@ const userAgentConditionSchema = z.object({
     .optional(),
   companion: z.boolean().optional(),
 });
+const viewConditionSchema = z.object({
+  condition: z.literal('view'),
+  views: z.string().array().optional(),
+});
 
 export const advancedCameraCardConditionSchema = z.discriminatedUnion('condition', [
   // Stock conditions:
-  stateConditionSchema,
   numericStateConditionSchema,
   screenConditionSchema,
+  stateConditionSchema,
   usersConditionSchema,
 
   // Custom conditions:
-  viewConditionSchema,
-  fullscreenConditionSchema,
-  expandConditionSchema,
   cameraConditionSchema,
-  mediaLoadedConditionSchema,
+  configConditionSchema,
   displayModeConditionSchema,
-  triggeredConditionSchema,
+  expandConditionSchema,
+  fullscreenConditionSchema,
+  initializedConditionSchema,
   interactionConditionSchema,
-  microphoneConditionSchema,
   keyConditionSchema,
+  mediaLoadedConditionSchema,
+  microphoneConditionSchema,
+  triggeredConditionSchema,
   userAgentConditionSchema,
+  viewConditionSchema,
 ]);
 export type AdvancedCameraCardCondition = z.infer<
   typeof advancedCameraCardConditionSchema

--- a/tests/card-controller/config/config-manager.test.ts
+++ b/tests/card-controller/config/config-manager.test.ts
@@ -349,6 +349,8 @@ describe('ConfigManager', () => {
     it('should initialize background items', async () => {
       const api = createCardAPI();
       const stateManager = new ConditionStateManager();
+      const listener = vi.fn();
+      stateManager.addListener(listener);
       vi.mocked(api.getConditionStateManager).mockReturnValue(stateManager);
 
       const manager = new ConfigManager(api);
@@ -371,13 +373,24 @@ describe('ConfigManager', () => {
 
       expect(api.getDefaultManager().initializeIfNecessary).toBeCalledTimes(1);
       expect(api.getMediaPlayerManager().initializeIfNecessary).toBeCalledTimes(1);
+      expect(listener).not.toBeCalledWith(
+        expect.objectContaining({ change: { config: expect.anything() } }),
+      );
 
+      vi.mocked(api.getInitializationManager().isInitializedMandatory).mockReturnValue(
+        true,
+      );
       stateManager.setState({ fullscreen: true });
 
       await flushPromises();
 
       expect(api.getDefaultManager().initializeIfNecessary).toBeCalledTimes(2);
       expect(api.getMediaPlayerManager().initializeIfNecessary).toBeCalledTimes(2);
+
+      // Should set the config condition state.
+      expect(listener).toBeCalledWith(
+        expect.objectContaining({ change: { config: expect.anything() } }),
+      );
     });
   });
 });


### PR DESCRIPTION
These conditions are probably not hugely useful for most card users, but allows the inbuilt automation systems to be used for card internal operations.

[skip ci]