### PR TITLE
fix: Prevent gallery overflowing onto menu

### DIFF
--- a/src/scss/card.scss
+++ b/src/scss/card.scss
@@ -68,6 +68,8 @@ advanced-camera-card-loading {
 div.main {
   position: relative;
 
+  overflow: auto;
+
   width: 100%;
   height: 100%;
   margin: auto;


### PR DESCRIPTION
 - Closes #1937