### PR TITLE
fix: Avoid inadvertently resetting the `go2rtc` connection in some circumstances

### DIFF
--- a/src/components/live/providers/go2rtc/index.ts
+++ b/src/components/live/providers/go2rtc/index.ts
@@ -142,7 +142,7 @@ export class AdvancedCameraCardGo2RTC extends LitElement implements MediaPlayer 
     if (
       this._player &&
       changedProps.has('microphoneState') &&
-      this._player?.microphoneStream !== this.microphoneState?.stream
+      this._player.microphoneStream !== (this.microphoneState?.stream ?? null)
     ) {
       this._player.microphoneStream = this.microphoneState?.stream ?? null;
 


### PR DESCRIPTION
- Closes #1914