### PR TITLE
fix: Allow multiple date parsers to apply at the same folder hierarchy level

### DIFF
--- a/src/card-controller/folders/ha/metadata-generator.ts
+++ b/src/card-controller/folders/ha/metadata-generator.ts
@@ -51,8 +51,11 @@ export class MetadataGenerator {
       }
       if (parser.type === 'startdate' || parser.type === 'date') {
         metadata.startDate =
-          this._parseDate(parser, valueToParse, parent?._metadata?.startDate) ??
-          undefined;
+          this._parseDate(
+            parser,
+            valueToParse,
+            metadata.startDate ?? parent?._metadata?.startDate,
+          ) ?? undefined;
       }
     }
 
@@ -83,7 +86,7 @@ export class MetadataGenerator {
     if (!Object.keys(result).length) {
       return undefined;
     }
-    return this._anyDateParser.fromObject({
+    const candidate = this._anyDateParser.fromObject({
       ...(base && {
         year: base.getFullYear(),
         month: base.getMonth() + 1,
@@ -95,5 +98,6 @@ export class MetadataGenerator {
       }),
       ...result,
     });
+    return isValidDate(candidate) ? candidate : undefined;
   }
 }

--- a/tests/card-controller/folders/ha/metadata-generator.test.ts
+++ b/tests/card-controller/folders/ha/metadata-generator.test.ts
@@ -115,6 +115,19 @@ describe('MetadataGenerator', () => {
           ).toBeUndefined();
         });
 
+        it('should fail to generate start date with invalid date', async () => {
+          const badBrowseMedia = createBrowseMedia({
+            title: '20250507AM',
+          });
+          const generator = new MetadataGenerator();
+          await generator.prepare([formatlessDateParser]);
+
+          expect(
+            generator.generate(badBrowseMedia, undefined, [formatlessDateParser])
+              ?.startDate,
+          ).toBeUndefined();
+        });
+
         it('should incorporate parent metadata without a date format', async () => {
           const parentBrowseMedia = createRichBrowseMedia({
             title: '2025-05-26',
@@ -162,6 +175,29 @@ describe('MetadataGenerator', () => {
           expect(
             generator.generate(browseMedia, undefined, [dateParser])?.startDate,
           ).toBeUndefined();
+        });
+
+        it('should use multiple parsed dates together', async () => {
+          const browseMedia = createBrowseMedia({
+            title: 'Foscam C1-20250507-171758-1746631078004-3.mp4',
+          });
+          const parsers: Parser[] = [
+            {
+              type: 'date',
+              regexp: '\\d{8}',
+            },
+            {
+              type: 'date',
+              regexp: '-(?<value>\\d{6})-',
+              format: 'HHmmss',
+            },
+          ];
+          const generator = new MetadataGenerator();
+          await generator.prepare(parsers);
+
+          expect(generator.generate(browseMedia, undefined, parsers)?.startDate).toEqual(
+            new Date('2025-05-07T17:17:58.000Z'),
+          );
         });
 
         it('should incorporate parent metadata with a date format', async () => {


### PR DESCRIPTION
- For: #1748