### PR TITLE
fix: Preserve parsers/matches on folder navigation

### DIFF
--- a/src/card-controller/folders/executor.ts
+++ b/src/card-controller/folders/executor.ts
@@ -2,7 +2,7 @@ import { ConditionState } from '../../conditions/types';
 import { FolderConfig, FolderType, folderTypeSchema } from '../../config/schema/folders';
 import { HomeAssistant } from '../../ha/types';
 import { Endpoint } from '../../types';
-import { ViewItem } from '../../view/item';
+import { ViewFolder, ViewItem } from '../../view/item';
 import { ViewItemCapabilities } from '../../view/types';
 import { sortItems } from '../view/sort';
 import { HAFoldersEngine } from './ha/engine';
@@ -18,6 +18,18 @@ export class FoldersExecutor {
   public generateDefaultFolderQuery(folder: FolderConfig): FolderQuery | null {
     return (
       this._getFolderEngine(folder.type)?.generateDefaultFolderQuery(folder) ?? null
+    );
+  }
+
+  public generateChildFolderQuery(
+    query: FolderQuery,
+    folder: ViewFolder,
+  ): FolderQuery | null {
+    return (
+      this._getFolderEngine(query.folder.type)?.generateChildFolderQuery(
+        query,
+        folder,
+      ) ?? null
     );
   }
 

--- a/src/card-controller/folders/manager.ts
+++ b/src/card-controller/folders/manager.ts
@@ -3,7 +3,7 @@ import { ConditionState } from '../../conditions/types';
 import { FolderConfig, FolderConfigWithoutID } from '../../config/schema/folders';
 import { localize } from '../../localize/localize';
 import { Endpoint } from '../../types';
-import { ViewItem } from '../../view/item';
+import { ViewFolder, ViewItem } from '../../view/item';
 import { ViewItemCapabilities } from '../../view/types';
 import { CardFoldersAPI } from '../types';
 import { FoldersExecutor } from './executor';
@@ -60,6 +60,13 @@ export class FoldersManager {
   public generateDefaultFolderQuery(folder?: FolderConfig): FolderQuery | null {
     const _folder = folder ?? this.getFolder();
     return _folder ? this._executor.generateDefaultFolderQuery(_folder) : null;
+  }
+
+  public generateChildFolderQuery(
+    query: FolderQuery,
+    folder: ViewFolder,
+  ): FolderQuery | null {
+    return this._executor.generateChildFolderQuery(query, folder);
   }
 
   public async expandFolder(

--- a/src/card-controller/folders/types.ts
+++ b/src/card-controller/folders/types.ts
@@ -48,6 +48,8 @@ export interface DownloadHelpers {
 
 export interface FoldersEngine {
   generateDefaultFolderQuery(folder: FolderConfig): FolderQuery | null;
+  generateChildFolderQuery(query: FolderQuery, folder: ViewFolder): FolderQuery | null;
+
   expandFolder(
     hass: HomeAssistant,
     query: FolderQuery,

--- a/src/components-lib/gallery/folder-gallery-controller.ts
+++ b/src/components-lib/gallery/folder-gallery-controller.ts
@@ -1,3 +1,4 @@
+import { FoldersManager } from '../../card-controller/folders/manager';
 import { ViewManagerInterface } from '../../card-controller/view/types';
 import { THUMBNAIL_WIDTH_DEFAULT } from '../../config/schema/common/controls/thumbnails';
 import { MediaGalleryThumbnailsConfig } from '../../config/schema/media-gallery';
@@ -43,6 +44,7 @@ export class FolderGalleryController {
     viewManager: ViewManagerInterface,
     item: ViewItem,
     ev: Event,
+    foldersManager?: FoldersManager,
   ): void {
     stopEventFromActivatingCardWideActions(ev);
 
@@ -64,16 +66,18 @@ export class FolderGalleryController {
       QueryClassifier.isFolderQuery(view.query)
     ) {
       const rawQuery = view.query.getQuery();
-      const id = item.getID();
-      if (!rawQuery || !id) {
+      if (!rawQuery || !foldersManager) {
         return;
       }
+
+      const newQuery = foldersManager.generateChildFolderQuery(rawQuery, item);
+      if (!newQuery) {
+        return;
+      }
+
       viewManager.setViewByParametersWithExistingQuery({
         params: {
-          query: view.query.clone().setQuery({
-            folder: rawQuery.folder,
-            path: [...rawQuery.path, { folder: item }],
-          }),
+          query: view.query.clone().setQuery(newQuery),
         },
       });
     }

--- a/src/components/gallery/folder-gallery.ts
+++ b/src/components/gallery/folder-gallery.ts
@@ -8,6 +8,7 @@ import {
 } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { FoldersManager } from '../../card-controller/folders/manager.js';
 import { ViewItemManager } from '../../card-controller/view/item-manager.js';
 import { ViewManagerEpoch } from '../../card-controller/view/types.js';
 import {
@@ -40,6 +41,9 @@ export class AdvancedCameraCardFolderGallery extends LitElement {
 
   @property({ attribute: false })
   public galleryConfig?: MediaGalleryConfig;
+
+  @property({ attribute: false })
+  public foldersManager?: FoldersManager;
 
   protected _controller = new FolderGalleryController(this);
 
@@ -88,7 +92,7 @@ export class AdvancedCameraCardFolderGallery extends LitElement {
           this._renderThumbnail(item, item === selected, (item: ViewItem, ev: Event) => {
             const manager = this.viewManagerEpoch?.manager;
             if (manager) {
-              this._controller.itemClickHandler(manager, item, ev);
+              this._controller.itemClickHandler(manager, item, ev, this.foldersManager);
             }
           }),
         )}

--- a/src/components/views.ts
+++ b/src/components/views.ts
@@ -218,6 +218,7 @@ export class AdvancedCameraCardViews extends LitElement {
             .viewManagerEpoch=${this.viewManagerEpoch}
             .viewItemManager=${this.viewItemManager}
             .galleryConfig=${this.config.media_gallery}
+            .foldersManager=${this.foldersManager}
           ></advanced-camera-card-folder-gallery>`
         : ``}
       ${

--- a/tests/card-controller/folders/executor.test.ts
+++ b/tests/card-controller/folders/executor.test.ts
@@ -130,6 +130,38 @@ describe('FoldersExecutor', () => {
     });
   });
 
+  describe('generateChildFolderQuery', () => {
+    it('should generate child folder query', () => {
+      const folder: FolderConfig = createFolder();
+      const query: FolderQuery = {
+        folder,
+        path: [{ ha: { id: 'media-source://' } }],
+      };
+      const viewFolder = new ViewFolder(folder);
+
+      const haFolderEngine = mock<HAFoldersEngine>();
+      haFolderEngine.generateChildFolderQuery.mockReturnValue(query);
+      const executor = new FoldersExecutor({ ha: haFolderEngine });
+
+      expect(executor.generateChildFolderQuery(query, viewFolder)).toEqual(query);
+      expect(haFolderEngine.generateChildFolderQuery).toBeCalledWith(query, viewFolder);
+    });
+
+    it('should return null for non-existent folder engine', () => {
+      const folder: FolderConfig = {
+        type: 'UNKNOWN',
+      } as unknown as FolderConfig;
+      const query: FolderQuery = {
+        folder,
+        path: [{ ha: { id: 'media-source://' } }],
+      };
+      const viewFolder = new ViewFolder(folder);
+      const executor = new FoldersExecutor();
+
+      expect(executor.generateChildFolderQuery(query, viewFolder)).toBeNull();
+    });
+  });
+
   describe('expandFolder', () => {
     it('should reject folders of the wrong type', async () => {
       const query = {

--- a/tests/card-controller/folders/manager.test.ts
+++ b/tests/card-controller/folders/manager.test.ts
@@ -6,6 +6,7 @@ import { FolderQuery } from '../../../src/card-controller/folders/types';
 import { FolderConfig, FolderConfigWithoutID } from '../../../src/config/schema/folders';
 import { ResolvedMediaCache } from '../../../src/ha/resolved-media';
 import { Endpoint } from '../../../src/types';
+import { ViewFolder } from '../../../src/view/item';
 import { ViewItemCapabilities } from '../../../src/view/types';
 import {
   createCardAPI,
@@ -177,6 +178,25 @@ describe('FoldersManager', () => {
       const manager = new FoldersManager(createCardAPI(), executor);
 
       expect(manager.generateDefaultFolderQuery(folder)).toEqual(query);
+    });
+  });
+
+  describe('generateChildFolderQuery', () => {
+    it('should generate child folder query', () => {
+      const folder: FolderConfig = createFolder();
+      const query: FolderQuery = {
+        folder,
+        path: [{ ha: { id: 'media-source://' } }],
+      };
+      const viewFolder = new ViewFolder(folder);
+
+      const executor = mock<FoldersExecutor>();
+      vi.mocked(executor.generateChildFolderQuery).mockReturnValue(query);
+
+      const manager = new FoldersManager(createCardAPI(), executor);
+
+      expect(manager.generateChildFolderQuery(query, viewFolder)).toEqual(query);
+      expect(executor.generateChildFolderQuery).toBeCalledWith(query, viewFolder);
     });
   });
 


### PR DESCRIPTION
 - Closes #2231 