### PR TITLE
fix: Fix camera_ui URL construction for Frigate engine

### DIFF
--- a/src/camera-manager/frigate/engine-frigate.ts
+++ b/src/camera-manager/frigate/engine-frigate.ts
@@ -934,7 +934,7 @@ export class FrigateCameraManagerEngine
       }
 
       const cameraURL =
-        `${cameraConfig.frigate.url}/cameras/` + cameraConfig.frigate.camera_name;
+        `${cameraConfig.frigate.url}/#` + cameraConfig.frigate.camera_name;
 
       if (context?.view === 'live') {
         return { endpoint: cameraURL };


### PR DESCRIPTION
When trying to open the camera ui for a Frigate camera from the card, it currently sends you to `frigate.url/cameras/camera_name`. That, however, (at least for me on Frigate on Frigate 16.3) just redirects you to the Frigate main page. (Same as if you tried to access `frigate.url/asdasdasdasd` i.e. path does not exist).  
Camera urls are of type `frigate.url/#camera_name`, maybe this was changed in some Frigate version.

I am not familiar with this project's code, but this place however seemed like the correct place for a fix.  
Let me know if there are some other considerations that should be verified. 

Also, I tried to run tests to see that my change isn't breaking any tests, but running tests before & after this change resulted in 15 failed tests. The number didn't go up, so I'll assume this didn't further break any test.  
(Btw, seems like almost all the failed tests are of this form, so I'm assuming something just goes wrong which makes these tests timezone dependent)
```diff
- Expected
+ Received

- 2025-05-26T22:42:00.000Z
+ 2025-05-26T19:42:00.000Z
```
