### PR TITLE
fix: remote_control cannot be overridden

### DIFF
--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -718,38 +718,3 @@ export const createRichBrowseMedia = (
     },
   };
 };
-
-/**
- * Create a ConfigManager test setup with real AutomationsManager and ConditionStateManager.
- * Includes spies for automation manager methods to track calls in tests.
- */
-export function createConfigManagerTestSetup(options?: {
-  hasHASS?: boolean;
-  isInitializedMandatory?: boolean;
-}) {
-  const api = createCardAPI();
-  const stateManager = new ConditionStateManager();
-  vi.mocked(api.getConditionStateManager).mockReturnValue(stateManager);
-
-  const automationsManager = new AutomationsManager(api);
-  vi.mocked(api.getAutomationsManager).mockReturnValue(automationsManager);
-  vi.mocked(api.getHASSManager().hasHASS).mockReturnValue(options?.hasHASS ?? true);
-  vi.mocked(api.getInitializationManager().isInitializedMandatory).mockReturnValue(
-    options?.isInitializedMandatory ?? true,
-  );
-
-  const manager = new ConfigManager(api);
-  vi.mocked(api.getConfigManager).mockReturnValue(manager);
-
-  const addAutomationsSpy = vi.spyOn(automationsManager, 'addAutomations');
-  const deleteAutomationsSpy = vi.spyOn(automationsManager, 'deleteAutomations');
-
-  return {
-    api,
-    manager,
-    stateManager,
-    automationsManager,
-    addAutomationsSpy,
-    deleteAutomationsSpy,
-  };
-}


### PR DESCRIPTION
### Problem
When configuration overrides are removed or changed for `remote_control`, the automations previously registered by the card were not updated, causing stale automations to remain active.

### Fix
Re-run the remote-control and automations loaders when the effective configuration changes due to overrides so that automation additions/removals reflect the current config.

#### What changed
- Modified: config-manager.ts
    - Call `setKeyboardShortcutsFromConfig(this._api)`, `setRemoteControlEntityFromConfig(this._api)` and `setAutomationsFromConfig(this._api)` inside `_processOverrideConfig()`.
- Modified: `config-manager.test.ts`
    - Added ConfigManager for test setup with real AutomationsManager and ConditionStateManager
    - Added test constants to centralize test data
    - Expanded test coverage for override conditions:
        - loaders should re-run when overrides change 
        - remote-control loader with overrides

#### Testing
- Full test suite run locally: 229 files, 2852 tests — all passing (with TZ forced to 'UTC')  ✅