### PR TITLE
docs: Clarify recorded clips button visibility in the `Responding to fullscreen` example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -58,9 +58,11 @@ cameras:
     capabilities:
       disable_except:
         - substream
-        # Without this the button for recorded clips will not get shown
+        # Optionally allow media on this substream.
         - clips
-        # Also allow PTZ controls on the substream.
+        - snapshots
+        - recordings
+        # Optionally allow PTZ controls on the substream.
         - ptz
 automations:
   - conditions:


### PR DESCRIPTION
Added capability "clips" to get button visibility for recorded clips when using the `Responding to fullscreen` example.


This example is almost exactly my use case, but i spent quite some time to find out exactly why the example killed my ability to watch recorded clips.