### PR TITLE
fix: prevent infinite resize loop in media grid Masonry layout

### DIFF
--- a/src/components-lib/media-grid-controller.ts
+++ b/src/components-lib/media-grid-controller.ts
@@ -278,8 +278,12 @@ export class MediaGridController {
       // Reset the column CSS sizes first.
       this._setColumnSizeStyles();
 
-      // Need to recreate the masonry layout since the column width will differ.
-      this._createMasonry();
+      // Update the column width on the existing Masonry instance rather than
+      // destroying and recreating it. A destroy resets the container height to
+      // 0, which can cause an ancestor scrollbar to appear/disappear, changing
+      // the available width and triggering an infinite resize oscillation.
+      this._masonry?.option?.({ columnWidth: this._getColumnSize() });
+      this._throttledLayout();
     }
   }
 

--- a/src/scss/editor.scss
+++ b/src/scss/editor.scss
@@ -1,7 +1,7 @@
 @use './button.scss';
 
 .option {
-  padding: 4px 4px;
+  padding: 8px 4px;
   cursor: pointer;
 }
 .option.option-overrides .title {
@@ -94,15 +94,16 @@ div.upgrade span {
   margin-top: 10px;
 }
 
-.submenu .controls {
+.submenu .values .controls {
   display: inline-block;
   margin-left: auto;
   margin-right: 0px;
   margin-bottom: 5px;
+  margin-top: 5px;
 }
-.submenu .controls ha-icon-button {
-  --mdc-icon-button-size: 32px;
-  --mdc-icon-size: calc(var(--mdc-icon-button-size) / 2);
+.submenu .values .controls ha-icon-button {
+  --ha-icon-button-size: 32px;
+  --mdc-icon-size: calc(var(--ha-icon-button-size) / 2);
 }
 span.info {
   padding: 10px;

--- a/src/scss/menu.scss
+++ b/src/scss/menu.scss
@@ -2,8 +2,8 @@
 
 :host {
   --advanced-camera-card-menu-button-size: 40px;
-  --mdc-icon-button-size: var(--advanced-camera-card-menu-button-size);
-  --mdc-icon-size: calc(var(--mdc-icon-button-size) / 2);
+  --ha-icon-button-size: var(--advanced-camera-card-menu-button-size);
+  --mdc-icon-size: calc(var(--ha-icon-button-size) / 2);
 
   pointer-events: auto;
 

--- a/src/scss/next-previous-control.scss
+++ b/src/scss/next-previous-control.scss
@@ -7,8 +7,8 @@
   );
   --advanced-camera-card-left-position: 45px;
   --advanced-camera-card-right-position: 45px;
-  --mdc-icon-button-size: var(--advanced-camera-card-next-prev-size);
-  --mdc-icon-size: calc(var(--mdc-icon-button-size) / 2);
+  --ha-icon-button-size: var(--advanced-camera-card-next-prev-size);
+  --mdc-icon-size: calc(var(--ha-icon-button-size) / 2);
 }
 
 .controls {


### PR DESCRIPTION
## Summary

Fixes an infinite resize oscillation in the media grid that prevents the camera grid from rendering on systems with classic (non-overlay) scrollbars.

## Problem

When `_hostResizeHandler` detects a width change, it calls `_createMasonry()` which **destroys** the existing Masonry instance (resetting the container height to 0) and creates a new one. This triggers an infinite loop:

1. Masonry `layout()` sets container height (e.g. ~4000px for 12 cameras)
2. Content now overflows the HA sections view, a **scrollbar appears** (~10px)
3. Scrollbar reduces available width (e.g. 2014px -> 2004px)
4. `_hostResizeHandler` fires, calls `_createMasonry()`, which **destroys** Masonry (height resets to 0)
5. Content no longer overflows, **scrollbar disappears**, width restores to 2014px
6. `_hostResizeHandler` fires again -> goto step 1

This cycles indefinitely (~6 destroy/recreate cycles per second), and the grid never visibly renders because the container height is reset to 0 on every cycle.