### PR TITLE
refactor(initialization): centralize CameraManager.destroy() inside uninitialize(CAMERAS)

### DIFF
--- a/src/card-controller/hass/hass-manager.ts
+++ b/src/card-controller/hass/hass-manager.ts
@@ -46,7 +46,6 @@ export class HASSManager {
       );
 
       this._api.getInitializationManager().uninitialize(InitializationAspect.CAMERAS);
-      this._api.getCameraManager().destroy();
       this._api.getInitializationManager().uninitialize(InitializationAspect.VIEW);
       this._api
         .getInitializationManager()

--- a/src/card-controller/initialization-manager.ts
+++ b/src/card-controller/initialization-manager.ts
@@ -210,6 +210,14 @@ export class InitializationManager {
   }
 
   public uninitialize(aspect: InitializationAspect): void {
+    // Destroying the camera manager when uninitializing CAMERAS releases held
+    // resources (WebSocket subscriptions via hass.connection.subscribeMessage,
+    // event listeners) before the CAMERAS init aspect replaces the instance
+    // via createCameraManager(). Without this, dropping the reference leaks
+    // those subscriptions.
+    if (aspect === InitializationAspect.CAMERAS) {
+      this._api.getCameraManager().destroy();
+    }
     this._initializer.uninitialize(aspect);
   }
 
@@ -220,7 +228,7 @@ export class InitializationManager {
       InitializationAspect.VIEW,
       InitializationAspect.INITIAL_TRIGGER,
     ]) {
-      this._initializer.uninitialize(aspect);
+      this.uninitialize(aspect);
     }
   }
 }

--- a/src/card-controller/issues/issues/initialization.ts
+++ b/src/card-controller/issues/issues/initialization.ts
@@ -40,11 +40,8 @@ export class InitializationIssue extends AbstractErrorIssue {
     this._error = null;
 
     // Reset init state so initializeMandatory() re-attempts on the next
-    // render cycle. destroy() releases the existing CameraManager's held
-    // resources (WebSocket subscriptions, listeners) before the CAMERAS
-    // init aspect replaces the instance via createCameraManager().
+    // render cycle.
     this._api.getInitializationManager().uninitializeMandatory();
-    this._api.getCameraManager().destroy();
     return false;
   }
 

--- a/tests/card-controller/hass/hass-manager.test.ts
+++ b/tests/card-controller/hass/hass-manager.test.ts
@@ -87,7 +87,6 @@ describe('HASSManager', () => {
       // to event sources (e.g. Frigate WebSocket events) on the next
       // render cycle.
       expect(api.getInitializationManager().uninitialize).toBeCalledWith('cameras');
-      expect(api.getCameraManager().destroy).toBeCalled();
       expect(api.getInitializationManager().uninitialize).toBeCalledWith('view');
       expect(api.getInitializationManager().uninitialize).toBeCalledWith(
         'initial-trigger',
@@ -106,7 +105,6 @@ describe('HASSManager', () => {
 
       // No reinit yet — HA isn't fully ready.
       expect(api.getInitializationManager().uninitialize).not.toBeCalled();
-      expect(api.getCameraManager().destroy).not.toBeCalled();
 
       // HA finishes booting.
       const readyHASS = createHASS();
@@ -115,7 +113,6 @@ describe('HASSManager', () => {
       manager.setHASS(readyHASS);
 
       expect(api.getInitializationManager().uninitialize).toBeCalledWith('cameras');
-      expect(api.getCameraManager().destroy).toBeCalled();
       expect(api.getInitializationManager().uninitialize).toBeCalledWith('view');
       expect(api.getInitializationManager().uninitialize).toBeCalledWith(
         'initial-trigger',
@@ -137,7 +134,6 @@ describe('HASSManager', () => {
 
       // WS came back but integrations still loading — wait for RUNNING.
       expect(api.getInitializationManager().uninitialize).not.toBeCalled();
-      expect(api.getCameraManager().destroy).not.toBeCalled();
     });
 
     it('should not reinitialize on first hass set (no previous hass)', () => {
@@ -153,7 +149,6 @@ describe('HASSManager', () => {
       // transition from, so the normal first-load init flow applies and we
       // must not blow away cameras.
       expect(api.getInitializationManager().uninitialize).not.toBeCalled();
-      expect(api.getCameraManager().destroy).not.toBeCalled();
     });
 
     it('should not reinitialize on ready → ready (no transition)', () => {
@@ -171,7 +166,6 @@ describe('HASSManager', () => {
       manager.setHASS(anotherReadyHASS);
 
       expect(api.getInitializationManager().uninitialize).not.toBeCalled();
-      expect(api.getCameraManager().destroy).not.toBeCalled();
     });
 
     it('should not crash when hass is null', () => {

--- a/tests/card-controller/initialization-manager.test.ts
+++ b/tests/card-controller/initialization-manager.test.ts
@@ -269,9 +269,10 @@ describe('InitializationManager', () => {
     });
   });
 
-  it('should uninitialize mandatory aspects', () => {
+  it('should uninitialize mandatory aspects and destroy camera manager once', () => {
+    const api = createCardAPI();
     const initializer = mock<Initializer>();
-    const manager = new InitializationManager(createCardAPI(), initializer);
+    const manager = new InitializationManager(api, initializer);
 
     manager.uninitializeMandatory();
 
@@ -283,14 +284,30 @@ describe('InitializationManager', () => {
     expect(initializer.uninitialize).toBeCalledWith(
       InitializationAspect.INITIAL_TRIGGER,
     );
+    // destroy() must be called exactly once (only for CAMERAS, not for the
+    // other three aspects).
+    expect(api.getCameraManager().destroy).toBeCalledTimes(1);
   });
 
-  it('should uninitialize', () => {
+  it('should uninitialize CAMERAS and call destroy', () => {
+    const api = createCardAPI();
     const initializer = mock<Initializer>();
-    const manager = new InitializationManager(createCardAPI(), initializer);
+    const manager = new InitializationManager(api, initializer);
 
     manager.uninitialize(InitializationAspect.CAMERAS);
 
     expect(initializer.uninitialize).toBeCalledWith(InitializationAspect.CAMERAS);
+    expect(api.getCameraManager().destroy).toBeCalled();
+  });
+
+  it('should uninitialize non-CAMERAS aspect without calling destroy', () => {
+    const api = createCardAPI();
+    const initializer = mock<Initializer>();
+    const manager = new InitializationManager(api, initializer);
+
+    manager.uninitialize(InitializationAspect.VIEW);
+
+    expect(initializer.uninitialize).toBeCalledWith(InitializationAspect.VIEW);
+    expect(api.getCameraManager().destroy).not.toBeCalled();
   });
 });

--- a/tests/card-controller/issues/issues/initialization.test.ts
+++ b/tests/card-controller/issues/issues/initialization.test.ts
@@ -125,7 +125,7 @@ describe('InitializationIssue', () => {
   });
 
   describe('retry', () => {
-    it('should uninitialize mandatory initialization and destroy camera manager', () => {
+    it('should uninitialize mandatory initialization', () => {
       const api = createAPI();
       const issue = new InitializationIssue(api);
       issue.trigger({ error: new Error('init failed') });
@@ -136,7 +136,6 @@ describe('InitializationIssue', () => {
       expect(issue.hasIssue()).toBe(false);
       expect(issue.needsRetry()).toBe(false);
       expect(api.getInitializationManager().uninitializeMandatory).toBeCalled();
-      expect(api.getCameraManager().destroy).toBeCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

Commit `a81d7237` stated the intent to call `CameraManager.destroy()` inside `InitializationManager.uninitialize(CAMERAS)`, but the implementation left callers responsible for pairing `uninitialize(CAMERAS)` with a manual `destroy()` call. This is a footgun: forgetting the destroy leaks WebSocket subscriptions (`hass.connection.subscribeMessage`) and event listeners held by the old camera manager instance.

- **`InitializationManager.uninitialize()`** now calls `getCameraManager().destroy()` automatically when the aspect is `CAMERAS`, before delegating to `_initializer.uninitialize()`.
- **`InitializationManager.uninitializeMandatory()`** is simplified to loop through aspects via `this.uninitialize()`, inheriting the destroy behaviour for free.
- **`HASSManager.setHASS()`** — removed the manual `getCameraManager().destroy()` call that preceded `uninitialize(CAMERAS)` in the reconnect path.
- **`InitializationIssue.retry()`** — removed the manual `getCameraManager().destroy()` call that preceded `uninitializeMandatory()`.
- All affected tests updated: `destroy()` assertions moved to `initialization-manager.test.ts` (the only layer that owns that contract); removed from `hass-manager.test.ts` and `issues/initialization.test.ts` where it was an implementation detail.

## Test plan

- [ ] `yarn run test` — all tests pass, 100% coverage for `card-controller/`
- [ ] `yarn run lint` — no lint errors
- [ ] Reconnect scenario: drop and restore HA WebSocket connection; verify cameras and triggers reinitialize correctly and no subscription leaks occur
- [ ] Retry scenario: trigger an initialization failure; click retry; verify the card recovers cleanly

---
_Generated by [Claude Code](https://claude.ai/code/session_01666K9pNfbTe4uvsidWzriZ)_