### PR TITLE
docs: Fix misnomer in docs 

### DIFF
--- a/docs/configuration/media-viewer.md
+++ b/docs/configuration/media-viewer.md
@@ -1,6 +1,6 @@
 # `media_viewer`
 
-The `media_player` section configures viewing all `clip`, `snapshot` or `recording` media, in either a media carousel or grid.
+The `media_viewer` section configures viewing all `clip`, `snapshot` or `recording` media, in either a media carousel or grid.
 
 ```yaml
 media_viewer:


### PR DESCRIPTION
Update 'media_player' to 'media_viewer'