### PR TITLE
feat: Auto-fill Frigate client ID

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -427,6 +427,11 @@ interface EditorMenuTarget {
   key: string | number;
 }
 
+interface ValueChangeItem {
+  key: string;
+  value: string | undefined;
+}
+
 const options: EditorOptions = {
   cameras: {
     icon: 'video',
@@ -1254,7 +1259,7 @@ export class AdvancedCameraCardEditor extends LitElement implements LovelaceCard
         .label=${this._getLabel(configPath)}
         .value=${getConfigValue(this._config, configPath, '')}
         .required=${false}
-        @value-changed=${(ev) => this._valueChangedHandler(configPath, ev)}
+        @value-changed=${(ev) => this._cameraChangedHandler(configPath, ev)}
       >
       </ha-selector>
     `;
@@ -3743,14 +3748,10 @@ export class AdvancedCameraCardEditor extends LitElement implements LovelaceCard
   }
 
   /**
-   * Handle a changed option value.
-   * @param ev Event triggering the change.
+   * Handle the extraction of event value.
+   * @param ev An event
    */
-  private _valueChangedHandler(key: string, ev: CustomEvent<{ value: unknown }>): void {
-    if (!this._config || !this.hass) {
-      return;
-    }
-
+  protected _extractEvent(ev: CustomEvent<{ value: unknown }>): string | undefined {
     let value;
     if (ev.detail && ev.detail.value !== undefined) {
       value = ev.detail.value;
@@ -3758,6 +3759,22 @@ export class AdvancedCameraCardEditor extends LitElement implements LovelaceCard
         value = value.trim();
       }
     }
+    return value;
+  }
+
+  /**
+   * Handle a changed option value.
+   * @param ev Event triggering the change.
+   */
+  protected _valueChangedHandler(
+    key: string,
+    ev: CustomEvent<{ value: unknown }>,
+  ): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const value = this._extractEvent(ev);
     if (getConfigValue(this._config, key) === value) {
       return;
     }
@@ -3769,6 +3786,63 @@ export class AdvancedCameraCardEditor extends LitElement implements LovelaceCard
       setConfigValue(newConfig, key, value);
     }
     this._updateConfig(newConfig);
+  }
+
+  /**
+   * Handle multiple changes to options.
+   * @param valueChange array of changes.
+   */
+  protected _batchValueChangedHandler(valueChange: ValueChangeItem[]): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const newConfig = copyConfig(this._config);
+    for (const { key, value } of valueChange) {
+      if (getConfigValue(newConfig, key) === value) {
+        continue;
+      }
+
+      if (value === '' || value === undefined) {
+        deleteConfigValue(newConfig, key);
+      } else {
+        setConfigValue(newConfig, key, value);
+      }
+    }
+    this._updateConfig(newConfig);
+  }
+
+  /**
+   * Determine frigate client id of camera if any to update with camera
+   * @param ev Camera selection event triggering the change
+   */
+  protected _cameraChangedHandler(
+    key: string,
+    ev: CustomEvent<{ value: unknown }>,
+  ): void {
+    if (!this._config || !this.hass) {
+      return;
+    }
+
+    const value = this._extractEvent(ev);
+    if (!value) {
+      this._valueChangedHandler(key, ev);
+      return;
+    }
+
+    const clientId = this.hass.states[value]?.attributes?.client_id;
+    if (clientId === '' || clientId === undefined) {
+      this._valueChangedHandler(key, ev);
+    } else {
+      const clientIdKey = `${key.substring(0, key.indexOf(']'))}].frigate.client_id`;
+      this._batchValueChangedHandler([
+        { key, value },
+        {
+          key: clientIdKey,
+          value: clientId !== 'frigate' ? clientId : '',
+        },
+      ]);
+    }
   }
 
   static get styles(): CSSResultGroup {


### PR DESCRIPTION
This PR allows the editor to automatically fill in the Frigate client ID when it's not the default `'frigate'` value instead of requiring the user to input it manually.

I've changed the function called by `<ha-selector>` to a new one that uses the selected camera attributes to get the Frigate client ID and refactored the previously used function `_valueChangedHandler` to avoid duplicate code.