### PR TITLE
feat: Add support for Frigate reviews / detections [initial PR] (#2315)

### DIFF
--- a/tests/config/profiles/casting.test.ts
+++ b/tests/config/profiles/casting.test.ts
@@ -1,33 +1,63 @@
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { getConfigValue } from '../../../src/config/management';
 import { CASTING_PROFILE } from '../../../src/config/profiles/casting';
 import { setProfiles } from '../../../src/config/profiles/set-profiles';
 import { advancedCameraCardConfigSchema } from '../../../src/config/schema/types';
 import { createRawConfig } from '../../test-utils';
 
-it('should contain expected defaults', () => {
-  expect(CASTING_PROFILE).toEqual({
-    'cameras_global.image.refresh_seconds': 1,
-    'dimensions.aspect_ratio_mode': 'static',
-    'dimensions.aspect_ratio': '16:9',
-    'live.auto_unmute': ['selected', 'visible'],
-    'live.controls.builtin': false,
-    'live.show_image_during_load': true,
-    'media_viewer.controls.builtin': false,
-    'menu.buttons.fullscreen.enabled': false,
-    'menu.buttons.media_player.enabled': false,
-    'menu.buttons.mute.enabled': true,
-    'menu.buttons.play.enabled': true,
-    'menu.style': 'none',
+describe('CASTING_PROFILE', () => {
+  it('should contain expected defaults', () => {
+    expect(CASTING_PROFILE).toEqual({
+      'cameras_global.image.refresh_seconds': 1,
+      'dimensions.aspect_ratio_mode': 'static',
+      'dimensions.aspect_ratio': '16:9',
+      'live.auto_unmute': ['selected', 'visible'],
+      'live.controls.builtin': false,
+      'live.show_image_during_load': true,
+      'media_viewer.controls.builtin': false,
+      'menu.buttons.fullscreen.enabled': false,
+      'menu.buttons.media_player.enabled': false,
+      'menu.buttons.mute.enabled': true,
+      'menu.buttons.play.enabled': true,
+      'menu.style': 'none',
+    });
   });
-});
 
-it('should be parseable after application', () => {
-  const rawInputConfig = createRawConfig();
-  const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+  it('should apply each profile value to the merged config', () => {
+    const rawInputConfig = createRawConfig();
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
 
-  setProfiles(rawInputConfig, parsedConfig, ['casting']);
+    setProfiles(rawInputConfig, parsedConfig, ['casting']);
 
-  // Reparse the config to ensure the profile did not introduce errors.
-  const parseResult = advancedCameraCardConfigSchema.safeParse(parsedConfig);
-  expect(parseResult.success, parseResult.error?.toString()).toBeTruthy();
+    for (const [path, expected] of Object.entries(CASTING_PROFILE)) {
+      expect(getConfigValue(parsedConfig, path), path).toEqual(expected);
+    }
+  });
+
+  it('should preserve user-specified values over profile values', () => {
+    const rawInputConfig = createRawConfig({
+      menu: { style: 'hover' },
+      live: { auto_unmute: [] },
+    });
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+
+    setProfiles(rawInputConfig, parsedConfig, ['casting']);
+
+    expect(parsedConfig.menu.style).toBe('hover');
+    expect(parsedConfig.live.auto_unmute).toEqual([]);
+
+    // Non-overridden profile values should still be applied.
+    expect(parsedConfig.live.controls.builtin).toBe(false);
+    expect(parsedConfig.dimensions.aspect_ratio_mode).toBe('static');
+  });
+
+  it('should be parseable after application', () => {
+    const rawInputConfig = createRawConfig();
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+
+    setProfiles(rawInputConfig, parsedConfig, ['casting']);
+
+    const parseResult = advancedCameraCardConfigSchema.safeParse(parsedConfig);
+    expect(parseResult.success, parseResult.error?.toString()).toBeTruthy();
+  });
 });

--- a/tests/config/profiles/low-performance.test.ts
+++ b/tests/config/profiles/low-performance.test.ts
@@ -1,71 +1,101 @@
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { getConfigValue } from '../../../src/config/management';
 import { LOW_PERFORMANCE_PROFILE } from '../../../src/config/profiles/low-performance';
 import { setProfiles } from '../../../src/config/profiles/set-profiles';
 import { advancedCameraCardConfigSchema } from '../../../src/config/schema/types';
 import { createRawConfig } from '../../test-utils';
 
-it('should contain expected defaults', () => {
-  expect(LOW_PERFORMANCE_PROFILE).toEqual({
-    'cameras_global.image.refresh_seconds': 10,
-    'cameras_global.live_provider': 'image',
-    'cameras_global.triggers.occupancy': false,
-    'live.auto_mute': [],
-    'live.controls.thumbnails.mode': 'none',
-    'live.controls.thumbnails.show_details': false,
-    'live.controls.thumbnails.show_download_control': false,
-    'live.controls.thumbnails.show_favorite_control': false,
-    'live.controls.thumbnails.show_timeline_control': false,
-    'live.controls.timeline.show_recordings': false,
-    'live.draggable': false,
-    'live.lazy_unload': ['unselected', 'hidden'],
-    'live.show_image_during_load': false,
-    'live.transition_effect': 'none',
-    'media_gallery.controls.thumbnails.show_details': false,
-    'media_gallery.controls.thumbnails.show_download_control': false,
-    'media_gallery.controls.thumbnails.show_favorite_control': false,
-    'media_gallery.controls.thumbnails.show_timeline_control': false,
-    'media_viewer.auto_mute': [],
-    'media_viewer.auto_pause': [],
-    'media_viewer.auto_play': [],
-    'media_viewer.controls.next_previous.style': 'chevrons',
-    'media_viewer.controls.thumbnails.mode': 'none',
-    'media_viewer.controls.thumbnails.show_details': false,
-    'media_viewer.controls.thumbnails.show_download_control': false,
-    'media_viewer.controls.thumbnails.show_favorite_control': false,
-    'media_viewer.controls.thumbnails.show_timeline_control': false,
-    'media_viewer.controls.timeline.show_recordings': false,
-    'media_viewer.draggable': false,
-    'media_viewer.snapshot_click_plays_clip': false,
-    'media_viewer.transition_effect': 'none',
-    'menu.buttons.iris.enabled': false,
-    'menu.buttons.media_player.enabled': false,
-    'menu.buttons.timeline.enabled': false,
-    'menu.style': 'outside',
-    'performance.features.animated_progress_indicator': false,
-    'performance.features.card_loading_indicator': false,
-    'performance.features.card_loading_effects': false,
-    'performance.features.max_simultaneous_engine_requests': 1,
-    'performance.features.media_chunk_size': 10,
-    'performance.style.border_radius': false,
-    'performance.style.box_shadow': false,
-    'status_bar.style': 'none',
-    'timeline.controls.thumbnails.mode': 'none',
-    'timeline.controls.thumbnails.show_details': false,
-    'timeline.controls.thumbnails.show_download_control': false,
-    'timeline.controls.thumbnails.show_favorite_control': false,
-    'timeline.controls.thumbnails.show_timeline_control': false,
-    'timeline.show_recordings': false,
-    'view.triggers.actions.trigger': 'none',
+describe('LOW_PERFORMANCE_PROFILE', () => {
+  it('should contain expected defaults', () => {
+    expect(LOW_PERFORMANCE_PROFILE).toEqual({
+      'cameras_global.image.refresh_seconds': 10,
+      'cameras_global.live_provider': 'image',
+      'cameras_global.triggers.occupancy': false,
+      'live.auto_mute': [],
+      'live.controls.thumbnails.mode': 'none',
+      'live.controls.thumbnails.show_details': false,
+      'live.controls.thumbnails.show_download_control': false,
+      'live.controls.thumbnails.show_favorite_control': false,
+      'live.controls.thumbnails.show_timeline_control': false,
+      'live.controls.timeline.show_recordings': false,
+      'live.draggable': false,
+      'live.lazy_unload': ['unselected', 'hidden'],
+      'live.show_image_during_load': false,
+      'live.transition_effect': 'none',
+      'media_gallery.controls.thumbnails.show_details': false,
+      'media_gallery.controls.thumbnails.show_download_control': false,
+      'media_gallery.controls.thumbnails.show_favorite_control': false,
+      'media_gallery.controls.thumbnails.show_timeline_control': false,
+      'media_viewer.auto_mute': [],
+      'media_viewer.auto_pause': [],
+      'media_viewer.auto_play': [],
+      'media_viewer.controls.next_previous.style': 'chevrons',
+      'media_viewer.controls.thumbnails.mode': 'none',
+      'media_viewer.controls.thumbnails.show_details': false,
+      'media_viewer.controls.thumbnails.show_download_control': false,
+      'media_viewer.controls.thumbnails.show_favorite_control': false,
+      'media_viewer.controls.thumbnails.show_timeline_control': false,
+      'media_viewer.controls.timeline.show_recordings': false,
+      'media_viewer.draggable': false,
+      'media_viewer.snapshot_click_plays_clip': false,
+      'media_viewer.transition_effect': 'none',
+      'menu.buttons.iris.enabled': false,
+      'menu.buttons.media_player.enabled': false,
+      'menu.buttons.timeline.enabled': false,
+      'menu.style': 'outside',
+      'performance.features.animated_progress_indicator': false,
+      'performance.features.card_loading_indicator': false,
+      'performance.features.card_loading_effects': false,
+      'performance.features.max_simultaneous_engine_requests': 1,
+      'performance.features.media_chunk_size': 10,
+      'performance.style.border_radius': false,
+      'performance.style.box_shadow': false,
+      'status_bar.style': 'none',
+      'timeline.controls.thumbnails.mode': 'none',
+      'timeline.controls.thumbnails.show_details': false,
+      'timeline.controls.thumbnails.show_download_control': false,
+      'timeline.controls.thumbnails.show_favorite_control': false,
+      'timeline.controls.thumbnails.show_timeline_control': false,
+      'timeline.show_recordings': false,
+      'view.triggers.actions.trigger': 'none',
+    });
   });
-});
 
-it('should be parseable after application', () => {
-  const rawInputConfig = createRawConfig();
-  const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+  it('should apply each profile value to the merged config', () => {
+    const rawInputConfig = createRawConfig();
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
 
-  setProfiles(rawInputConfig, parsedConfig, ['low-performance']);
+    setProfiles(rawInputConfig, parsedConfig, ['low-performance']);
 
-  // Reparse the config to ensure the profile did not introduce errors.
-  const parseResult = advancedCameraCardConfigSchema.safeParse(parsedConfig);
-  expect(parseResult.success, parseResult.error?.toString()).toBeTruthy();
+    for (const [path, expected] of Object.entries(LOW_PERFORMANCE_PROFILE)) {
+      expect(getConfigValue(parsedConfig, path), path).toEqual(expected);
+    }
+  });
+
+  it('should preserve user-specified values over profile values', () => {
+    const rawInputConfig = createRawConfig({
+      menu: { style: 'hover' },
+      live: { transition_effect: 'slide' },
+    });
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+
+    setProfiles(rawInputConfig, parsedConfig, ['low-performance']);
+
+    expect(parsedConfig.menu.style).toBe('hover');
+    expect(parsedConfig.live.transition_effect).toBe('slide');
+
+    // Non-overridden profile values should still be applied.
+    expect(parsedConfig.live.draggable).toBe(false);
+    expect(parsedConfig.performance.features.media_chunk_size).toBe(10);
+  });
+
+  it('should be parseable after application', () => {
+    const rawInputConfig = createRawConfig();
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+
+    setProfiles(rawInputConfig, parsedConfig, ['low-performance']);
+
+    const parseResult = advancedCameraCardConfigSchema.safeParse(parsedConfig);
+    expect(parseResult.success, parseResult.error?.toString()).toBeTruthy();
+  });
 });

--- a/tests/config/profiles/scrubbing.test.ts
+++ b/tests/config/profiles/scrubbing.test.ts
@@ -1,27 +1,55 @@
-import { expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { getConfigValue } from '../../../src/config/management';
 import { SCRUBBING_PROFILE } from '../../../src/config/profiles/scrubbing';
 import { setProfiles } from '../../../src/config/profiles/set-profiles';
 import { advancedCameraCardConfigSchema } from '../../../src/config/schema/types';
 import { createRawConfig } from '../../test-utils';
 
-it('should contain expected defaults', () => {
-  expect(SCRUBBING_PROFILE).toEqual({
-    'live.controls.timeline.mode': 'below',
-    'live.controls.timeline.style': 'ribbon',
-    'live.controls.timeline.pan_mode': 'seek',
-    'media_viewer.controls.timeline.mode': 'below',
-    'media_viewer.controls.timeline.style': 'ribbon',
-    'media_viewer.controls.timeline.pan_mode': 'seek',
+describe('SCRUBBING_PROFILE', () => {
+  it('should contain expected defaults', () => {
+    expect(SCRUBBING_PROFILE).toEqual({
+      'live.controls.timeline.mode': 'below',
+      'live.controls.timeline.style': 'ribbon',
+      'live.controls.timeline.pan_mode': 'seek',
+      'media_viewer.controls.timeline.mode': 'below',
+      'media_viewer.controls.timeline.style': 'ribbon',
+      'media_viewer.controls.timeline.pan_mode': 'seek',
+    });
   });
-});
 
-it('should be parseable after application', () => {
-  const rawInputConfig = createRawConfig();
-  const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+  it('should apply each profile value to the merged config', () => {
+    const rawInputConfig = createRawConfig();
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
 
-  setProfiles(rawInputConfig, parsedConfig, ['low-performance']);
+    setProfiles(rawInputConfig, parsedConfig, ['scrubbing']);
 
-  // Reparse the config to ensure the profile did not introduce errors.
-  const parseResult = advancedCameraCardConfigSchema.safeParse(parsedConfig);
-  expect(parseResult.success, parseResult.error?.toString()).toBeTruthy();
+    for (const [path, expected] of Object.entries(SCRUBBING_PROFILE)) {
+      expect(getConfigValue(parsedConfig, path), path).toEqual(expected);
+    }
+  });
+
+  it('should preserve user-specified values over profile values', () => {
+    const rawInputConfig = createRawConfig({
+      live: { controls: { timeline: { mode: 'none' } } },
+    });
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+
+    setProfiles(rawInputConfig, parsedConfig, ['scrubbing']);
+
+    expect(parsedConfig.live.controls.timeline.mode).toBe('none');
+
+    // Non-overridden profile values should still be applied.
+    expect(parsedConfig.live.controls.timeline.style).toBe('ribbon');
+    expect(parsedConfig.media_viewer.controls.timeline.mode).toBe('below');
+  });
+
+  it('should be parseable after application', () => {
+    const rawInputConfig = createRawConfig();
+    const parsedConfig = advancedCameraCardConfigSchema.parse(rawInputConfig);
+
+    setProfiles(rawInputConfig, parsedConfig, ['scrubbing']);
+
+    const parseResult = advancedCameraCardConfigSchema.safeParse(parsedConfig);
+    expect(parseResult.success, parseResult.error?.toString()).toBeTruthy();
+  });
 });

--- a/tests/config/schema/common/aspect-ratio.test.ts
+++ b/tests/config/schema/common/aspect-ratio.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { aspectRatioSchema } from '../../../../src/config/schema/common/aspect-ratio';
+
+describe('aspectRatioSchema', () => {
+  it('should parse a [w, h] tuple', () => {
+    expect(aspectRatioSchema.parse([16, 9])).toEqual([16, 9]);
+  });
+
+  it.each([
+    ['16:9', [16, 9]],
+    ['16/9', [16, 9]],
+    [' 4 : 3 ', [4, 3]],
+    ['1.5:1', [1.5, 1]],
+  ])('should parse string %s into a numeric tuple', (input, expected) => {
+    expect(aspectRatioSchema.parse(input)).toEqual(expected);
+  });
+
+  it('should reject a string with an unsupported separator', () => {
+    expect(aspectRatioSchema.safeParse('16-9').success).toBe(false);
+  });
+
+  it('should reject a non-numeric string', () => {
+    expect(aspectRatioSchema.safeParse('wide').success).toBe(false);
+  });
+
+  it('should reject an array of the wrong length', () => {
+    expect(aspectRatioSchema.safeParse([16]).success).toBe(false);
+    expect(aspectRatioSchema.safeParse([16, 9, 1]).success).toBe(false);
+  });
+
+  it('should reject an array of non-numbers', () => {
+    expect(aspectRatioSchema.safeParse(['16', '9']).success).toBe(false);
+  });
+});

--- a/tests/config/schema/common/image.test.ts
+++ b/tests/config/schema/common/image.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  imageBaseConfigDefault,
+  imageBaseConfigSchema,
+} from '../../../../src/config/schema/common/image';
+
+describe('imageBaseConfigSchema', () => {
+  it('should fill in defaults from an empty object', () => {
+    expect(imageBaseConfigSchema.parse({})).toEqual(imageBaseConfigDefault);
+  });
+
+  it.each(['auto', 'camera', 'default', 'entity', 'screensaver', 'url'])(
+    'should accept mode %s',
+    (mode) => {
+      expect(imageBaseConfigSchema.parse({ mode }).mode).toBe(mode);
+    },
+  );
+
+  it('should reject an unrecognised mode', () => {
+    expect(imageBaseConfigSchema.safeParse({ mode: 'panorama' }).success).toBe(false);
+  });
+
+  it('should accept refresh_seconds = "auto"', () => {
+    expect(imageBaseConfigSchema.parse({ refresh_seconds: 'auto' }).refresh_seconds)
+      .toBe('auto');
+  });
+
+  it('should accept a non-negative refresh_seconds', () => {
+    expect(imageBaseConfigSchema.parse({ refresh_seconds: 0 }).refresh_seconds).toBe(0);
+    expect(imageBaseConfigSchema.parse({ refresh_seconds: 5 }).refresh_seconds).toBe(5);
+  });
+
+  it('should reject a negative refresh_seconds', () => {
+    expect(imageBaseConfigSchema.safeParse({ refresh_seconds: -1 }).success).toBe(
+      false,
+    );
+  });
+
+  it('should reject a non-string url', () => {
+    expect(imageBaseConfigSchema.safeParse({ url: 123 }).success).toBe(false);
+  });
+});

--- a/tests/config/schema/common/pan.test.ts
+++ b/tests/config/schema/common/pan.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { panSchema } from '../../../../src/config/schema/common/pan';
+
+describe('panSchema', () => {
+  it('should parse coordinates within bounds', () => {
+    expect(panSchema.parse({ x: 0, y: 100 })).toEqual({ x: 0, y: 100 });
+    expect(panSchema.parse({ x: 50, y: 50 })).toEqual({ x: 50, y: 50 });
+  });
+
+  it('should accept partial coordinates', () => {
+    expect(panSchema.parse({ x: 25 })).toEqual({ x: 25 });
+    expect(panSchema.parse({})).toEqual({});
+  });
+
+  it('should reject coordinates below the minimum', () => {
+    expect(panSchema.safeParse({ x: -1 }).success).toBe(false);
+    expect(panSchema.safeParse({ y: -0.01 }).success).toBe(false);
+  });
+
+  it('should reject coordinates above the maximum', () => {
+    expect(panSchema.safeParse({ x: 101 }).success).toBe(false);
+    expect(panSchema.safeParse({ y: 100.01 }).success).toBe(false);
+  });
+});

--- a/tests/config/schema/common/proxy.test.ts
+++ b/tests/config/schema/common/proxy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  proxyBaseConfigDefault,
+  proxyBaseConfigSchema,
+  resolveProxyConfig,
+} from '../../../../src/config/schema/common/proxy';
+
+describe('proxyBaseConfigSchema', () => {
+  it('should fill in defaults from an empty object', () => {
+    expect(proxyBaseConfigSchema.parse({})).toEqual(proxyBaseConfigDefault);
+  });
+
+  it.each([true, false, 'auto'])(
+    'should accept ssl_verification value %s',
+    (value) => {
+      expect(proxyBaseConfigSchema.parse({ ssl_verification: value }).ssl_verification)
+        .toEqual(value);
+    },
+  );
+
+  it.each(['default', 'insecure', 'intermediate', 'modern', 'auto'])(
+    'should accept ssl_ciphers value %s',
+    (value) => {
+      expect(proxyBaseConfigSchema.parse({ ssl_ciphers: value }).ssl_ciphers).toEqual(
+        value,
+      );
+    },
+  );
+
+  it('should reject an unrecognised ssl_ciphers value', () => {
+    expect(proxyBaseConfigSchema.safeParse({ ssl_ciphers: 'banana' }).success).toBe(
+      false,
+    );
+  });
+
+  it('should reject an unrecognised ssl_verification value', () => {
+    expect(
+      proxyBaseConfigSchema.safeParse({ ssl_verification: 'sometimes' }).success,
+    ).toBe(false);
+  });
+
+  it('should reject a non-boolean dynamic value', () => {
+    expect(proxyBaseConfigSchema.safeParse({ dynamic: 'yes' }).success).toBe(false);
+  });
+});
+
+describe('resolveProxyConfig', () => {
+  it('should resolve the auto sentinels to concrete defaults', () => {
+    expect(
+      resolveProxyConfig({
+        dynamic: true,
+        ssl_verification: 'auto',
+        ssl_ciphers: 'auto',
+      }),
+    ).toEqual({
+      dynamic: true,
+      ssl_verification: true,
+      ssl_ciphers: 'default',
+    });
+  });
+
+  it('should pass through explicit values unchanged', () => {
+    expect(
+      resolveProxyConfig({
+        dynamic: false,
+        ssl_verification: false,
+        ssl_ciphers: 'modern',
+      }),
+    ).toEqual({
+      dynamic: false,
+      ssl_verification: false,
+      ssl_ciphers: 'modern',
+    });
+  });
+});

--- a/tests/config/schema/common/regex.test.ts
+++ b/tests/config/schema/common/regex.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { regexSchema } from '../../../../src/config/schema/common/regex';
+
+describe('regexSchema', () => {
+  it('should accept a valid regular expression', () => {
+    expect(regexSchema.parse('^[a-z]+$')).toBe('^[a-z]+$');
+  });
+
+  it('should accept the empty string', () => {
+    expect(regexSchema.parse('')).toBe('');
+  });
+
+  it('should reject a malformed regular expression', () => {
+    const result = regexSchema.safeParse('[unclosed');
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toBe('Invalid regular expression');
+  });
+
+  it('should reject non-string input', () => {
+    expect(regexSchema.safeParse(123).success).toBe(false);
+  });
+});

--- a/tests/config/schema/common/status-bar.test.ts
+++ b/tests/config/schema/common/status-bar.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STATUS_BAR_PRIORITY_DEFAULT,
+  STATUS_BAR_PRIORITY_MAX,
+} from '../../../../src/config/schema/common/const';
+import { statusBarItemBaseSchema } from '../../../../src/config/schema/common/status-bar';
+
+describe('statusBarItemBaseSchema', () => {
+  it('should default priority/enabled/permanent', () => {
+    expect(
+      statusBarItemBaseSchema.parse({
+        enabled: undefined,
+        permanent: undefined,
+        priority: undefined,
+      }),
+    ).toEqual({
+      enabled: true,
+      permanent: false,
+      priority: STATUS_BAR_PRIORITY_DEFAULT,
+    });
+  });
+
+  it('should accept boundary priorities', () => {
+    expect(statusBarItemBaseSchema.parse({ priority: 0 }).priority).toBe(0);
+    expect(
+      statusBarItemBaseSchema.parse({ priority: STATUS_BAR_PRIORITY_MAX }).priority,
+    ).toBe(STATUS_BAR_PRIORITY_MAX);
+  });
+
+  it('should reject a priority below 0', () => {
+    expect(statusBarItemBaseSchema.safeParse({ priority: -1 }).success).toBe(false);
+  });
+
+  it('should reject a priority above the maximum', () => {
+    expect(
+      statusBarItemBaseSchema.safeParse({ priority: STATUS_BAR_PRIORITY_MAX + 1 })
+        .success,
+    ).toBe(false);
+  });
+
+  it('should reject non-boolean enabled/permanent', () => {
+    expect(statusBarItemBaseSchema.safeParse({ enabled: 'yes' }).success).toBe(false);
+    expect(statusBarItemBaseSchema.safeParse({ permanent: 1 }).success).toBe(false);
+  });
+});

--- a/tests/config/schema/common/zoom.test.ts
+++ b/tests/config/schema/common/zoom.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ZOOM_MAX,
+  ZOOM_MIN,
+  zoomSchema,
+} from '../../../../src/config/schema/common/zoom';
+
+describe('zoomSchema', () => {
+  it('should accept the boundary values', () => {
+    expect(zoomSchema.parse(ZOOM_MIN)).toBe(ZOOM_MIN);
+    expect(zoomSchema.parse(ZOOM_MAX)).toBe(ZOOM_MAX);
+  });
+
+  it('should accept values within the bounds', () => {
+    expect(zoomSchema.parse(2.5)).toBe(2.5);
+  });
+
+  it('should reject values below the minimum', () => {
+    expect(zoomSchema.safeParse(ZOOM_MIN - 0.01).success).toBe(false);
+  });
+
+  it('should reject values above the maximum', () => {
+    expect(zoomSchema.safeParse(ZOOM_MAX + 0.01).success).toBe(false);
+  });
+
+  it('should reject non-numeric input', () => {
+    expect(zoomSchema.safeParse('5').success).toBe(false);
+  });
+});


### PR DESCRIPTION
- Add support for Frigate reviews / detections.
 - Add support for GenAI metadata.
- Significant internal refactor to more flexible "UnifiedQuery" to allow
mixing cameras with simple metadata and review metadata (e.g. a timeline
view of a Frigate camera with reviews, and a Reolink camera with simple
metadata).
 - Add support for folder media as camera media.

There are a few more PRs to commit prior to this going live, but
commiting this for now due to the scale of the change.

BREAKING CHANGE: `media_type` and `events_type` are retired under
`live`, `viewer` and `timeline` configuration sections, instead media
type is associated (once) with the camera under `media`.