### PR TITLE
ci: Add triage labels (priority, regression, fixed-pending-release)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -38,3 +38,25 @@
 - name: waiting
   description: Waiting for something
   color: daa036
+
+# Priority labels
+- name: P0
+  description: 'Priority: Blocker'
+  color: b60205
+- name: P1
+  description: 'Priority: High'
+  color: d93f0b
+- name: P2
+  description: 'Priority: Medium'
+  color: fbca04
+- name: P3
+  description: 'Priority: Low'
+  color: 0e8a16
+
+# Triage labels
+- name: regression
+  description: Worked in a previous version
+  color: e11d21
+- name: fixed-pending-release
+  description: Awaiting Release
+  color: 1d76db


### PR DESCRIPTION
## What

Registers the labels used to curate the ACC Project Board, in `.github/labels.yml` (your `labeler` workflow syncs them on merge to `main`):

- **`P0`–`P3`** — priority (Blocker / High / Medium / Low)
- **`regression`** — worked in a previous version
- **`fixed-pending-release`** — merged to `dev`, awaiting a release

## Notes

- **Release targets are tracked via GitHub Milestones**, not labels — so no `v8.0.0-rc.*` labels here.
- Category stays on the existing conventional-commit labels (`bug`, `feature`, …).
- One file; no code, no automation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011HVLLcMgAcEmSSSk3wqGCh)_