### PR TITLE
feat: Add `answered` option to call condition/trigger

### DIFF
--- a/docs/configuration/conditions-triggers.md
+++ b/docs/configuration/conditions-triggers.md
@@ -94,9 +94,20 @@ conditions:
 
 ## `call`
 
-Matches whether a [two-way audio](../usage/2-way-audio.md) call is in progress.
-As a **condition**, true while the call state matches; as a **trigger**, fires
-when it becomes a match (e.g. `call: true` fires when a call starts).
+Matches whether a [two-way audio](../usage/2-way-audio.md) call is in progress,
+and optionally whether it has been answered. As a **condition**, true while the
+call state matches; as a **trigger**, fires when it becomes a match (e.g.
+`call: true` fires when a call starts).
+
+`answered` additionally matches whether the call was picked up:
+
+- `answered: true`: the call was answered.
+- `answered: false`: the call was never answered (rejected or timed out).
+- Omitted: matches either way.
+
+Omitting `answered` also means a `call: true` trigger fires only when the call
+starts, not when a ringing call is later answered. Add `answered: true` to fire
+on the answer.
 
 ```yaml
 # As a condition:
@@ -107,12 +118,23 @@ conditions:
 triggers:
   - trigger: call
     call: true
+
+  # Fires when a ringing call is answered.
+  - trigger: call
+    call: true
+    answered: true
+
+  # Fires when a call ends unanswered (rejected or timed out).
+  - trigger: call
+    call: false
+    answered: false
 ```
 
-| Parameter               | Description                                                                                    |
-| ----------------------- | ---------------------------------------------------------------------------------------------- |
-| `condition` / `trigger` | Must be `call`.                                                                                |
-| `call`                  | If `true` or `false`, matches when a two-way audio call is or is not in progress respectively. |
+| Parameter               | Description                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `condition` / `trigger` | Must be `call`.                                                                                                                                  |
+| `call`                  | If `true` or `false`, matches when a two-way audio call is or is not in progress respectively.                                                   |
+| `answered`              | If `true` or `false`, additionally requires the call to have or not have been answered respectively. Omit to match regardless of answered state. |
 
 ## `camera`
 
@@ -715,6 +737,7 @@ conditions:
         views: [live]
   - condition: call
     call: true
+    answered: true
   - condition: camera
     cameras:
       - camera.office
@@ -780,6 +803,7 @@ conditions:
 triggers:
   - trigger: call
     call: true
+    answered: true
   - trigger: camera
     cameras:
       - camera.office

--- a/src/card-controller/call/manager.ts
+++ b/src/card-controller/call/manager.ts
@@ -158,7 +158,7 @@ export class CallManager {
       modifiers: [new SubstreamViewModifier({ stream: callCameraID, camera: parentID })],
       force: true,
     });
-    this._api.getConditionStateManager().setState({ call: true });
+    this._api.getConditionStateManager().setState({ call: { active: true, answered } });
 
     // Re-read the session as the listeners triggered by `call: true` may have
     // already have changed the state.
@@ -208,6 +208,9 @@ export class CallManager {
     // change. The `update()` below forces card.ts to re-render and re-read
     // `getCall()`, propagating the new session to the carousel.
     this._call = { ...this._call, answered: true };
+    this._api
+      .getConditionStateManager()
+      .setState({ call: { active: true, answered: true } });
     this._api.getCardElementManager().update();
     return true;
   }
@@ -245,8 +248,11 @@ export class CallManager {
     this._ringtone.stop();
     this._unansweredTimer.stop();
     if (this._call) {
+      const answered = this._call.answered;
       this._call = null;
-      this._api.getConditionStateManager().setState({ call: false });
+      this._api
+        .getConditionStateManager()
+        .setState({ call: { active: false, answered } });
     }
     this._api
       .getConditionStateManager()
@@ -265,6 +271,7 @@ export class CallManager {
     }
     const call = this._call;
     const previousView = call.previousView;
+    const answered = call.answered;
 
     // Silence any ringtone before the navigation.
     this._ringtone.stop();
@@ -304,7 +311,7 @@ export class CallManager {
         force: true,
       });
     }
-    this._api.getConditionStateManager().setState({ call: false });
+    this._api.getConditionStateManager().setState({ call: { active: false, answered } });
     return true;
   }
 

--- a/src/condition-trigger/conditions/conditions/call.ts
+++ b/src/condition-trigger/conditions/conditions/call.ts
@@ -10,8 +10,15 @@ export class CallConditionEvaluator implements ConditionEvaluator {
   }
 
   public evaluate(newState?: ConditionState): ConditionsEvaluationResult {
+    const call = newState?.call;
+    const activeMatches =
+      this._condition.call === undefined ||
+      this._condition.call === (call?.active ?? false);
+    const answeredMatches =
+      this._condition.answered === undefined ||
+      this._condition.answered === (call?.answered ?? false);
     return {
-      result: this._condition.call === (newState?.call ?? false),
+      result: activeMatches && answeredMatches,
     };
   }
 }

--- a/src/condition-trigger/conditions/types.ts
+++ b/src/condition-trigger/conditions/types.ts
@@ -16,7 +16,7 @@ import type { MediaLoadedInfo } from '../../types';
 // Counterexample: Rebuilding an equivalent function callback each write making
 // the field look changed when nothing observable did.
 export interface ConditionState {
-  call?: boolean;
+  call?: { active: boolean; answered: boolean };
   camera?: string;
   // The engaged substream for the selected camera (absent when the camera's own
   // stream is used).

--- a/src/condition-trigger/triggers/triggers/call.ts
+++ b/src/condition-trigger/triggers/triggers/call.ts
@@ -4,6 +4,10 @@ import type { TriggerOfType } from './types';
 
 export class CallTrigger extends ConditionStateTriggerBase<TriggerOfType<'call'>> {
   protected _getValue(state: ConditionState): unknown {
-    return state.call ?? false;
+    const call = state.call ?? { active: false, answered: false };
+    // Only watch `answered` when the trigger config cares about it -- keeps
+    // a plain `call: true`/`call: false` trigger firing solely on the
+    // active/inactive edge, unaffected by an answer happening mid-call.
+    return this._trigger.answered === undefined ? call.active : call;
   }
 }

--- a/src/config/schema/condition-trigger/common/call.ts
+++ b/src/config/schema/condition-trigger/common/call.ts
@@ -2,5 +2,6 @@ import { z } from 'zod';
 
 export const callBaseSchema = z.object({
   call: z.boolean().optional(),
+  answered: z.boolean().optional(),
 });
 export type CallBase = z.infer<typeof callBaseSchema>;

--- a/tests/card-controller/call/manager.test.ts
+++ b/tests/card-controller/call/manager.test.ts
@@ -145,7 +145,9 @@ describe('start', () => {
       modifiers: [expect.any(SubstreamViewModifier)],
       force: true,
     });
-    expect(api.getConditionStateManager().setState).toBeCalledWith({ call: true });
+    expect(api.getConditionStateManager().setState).toBeCalledWith({
+      call: { active: true, answered: true },
+    });
   });
 
   it('should navigate to the live view when started from elsewhere', async () => {
@@ -367,8 +369,12 @@ describe('start', () => {
     expect(call?.cameraID).toBe('camera.garage');
     expect(call?.previousView?.view).toBe('live');
     expect(call?.previousView?.camera).toBe('camera.office');
-    expect(api.getConditionStateManager().setState).toBeCalledWith({ call: false });
-    expect(api.getConditionStateManager().setState).toBeCalledWith({ call: true });
+    expect(api.getConditionStateManager().setState).toBeCalledWith({
+      call: { active: false, answered: true },
+    });
+    expect(api.getConditionStateManager().setState).toBeCalledWith({
+      call: { active: true, answered: true },
+    });
   });
 
   it('should restart on the same camera with a different stream', async () => {
@@ -656,7 +662,9 @@ describe('end', () => {
       modifiers: [expect.any(SubstreamViewModifier)],
       force: true,
     });
-    expect(api.getConditionStateManager().setState).toBeCalledWith({ call: false });
+    expect(api.getConditionStateManager().setState).toBeCalledWith({
+      call: { active: false, answered: true },
+    });
   });
 
   it('should restore the pre-call substream when ending', async () => {
@@ -1085,7 +1093,9 @@ describe('initialize / uninitialize', () => {
     manager.uninitialize();
 
     expect(manager.isActive()).toBe(false);
-    expect(api.getConditionStateManager().setState).toBeCalledWith({ call: false });
+    expect(api.getConditionStateManager().setState).toBeCalledWith({
+      call: { active: false, answered: true },
+    });
   });
 
   it('should ignore further condition state changes after uninitialize', async () => {
@@ -1293,6 +1303,9 @@ describe('answer', () => {
     expect(after).not.toBe(before);
     expect(after?.cameraID).toBe(before?.cameraID);
     expect(after?.inbound).toBe(before?.inbound);
+    expect(api.getConditionStateManager().setState).toBeCalledWith({
+      call: { active: true, answered: true },
+    });
   });
 
   it('should stop the ringtone and unanswered timer on answer', async () => {
@@ -1564,7 +1577,7 @@ describe('unanswered timeout', () => {
   });
 });
 
-// `start()` calls `setState({ call: true })` to broadcast the new call status;
+// `start()` calls `setState({ call: { active: true, ... } })` to broadcast the new call status;
 // a listener that responds by navigating away will fire the manager's own
 // condition listener and end the call before `start()` returns. Verify the
 // post-setState re-read of the session prevents follow-up work (ringtone /
@@ -1591,10 +1604,10 @@ describe('session end during setState', () => {
     const listener = getConditionStateListener(api);
 
     vi.mocked(api.getConditionStateManager().setState).mockImplementation((state) => {
-      // Simulate a downstream listener that responds to `call: true` by
-      // navigating away. The manager's own listener then ends the call,
+      // Simulate a downstream listener that responds to `call: { active: true }`
+      // by navigating away. The manager's own listener then ends the call,
       // nulling the session before `start()` finishes.
-      if (state.call === true) {
+      if (state.call?.active === true) {
         listener({
           old: { camera: 'camera.office', view: 'live' },
           change: { view: 'clips' },

--- a/tests/condition-trigger/conditions/conditions/call.test.ts
+++ b/tests/condition-trigger/conditions/conditions/call.test.ts
@@ -17,8 +17,12 @@ describe('call condition', () => {
     );
 
     expect(evaluator.evaluate({}).result).toBeFalsy();
-    expect(evaluator.evaluate({ call: true }).result).toBeTruthy();
-    expect(evaluator.evaluate({ call: false }).result).toBeFalsy();
+    expect(
+      evaluator.evaluate({ call: { active: true, answered: false } }).result,
+    ).toBeTruthy();
+    expect(
+      evaluator.evaluate({ call: { active: false, answered: false } }).result,
+    ).toBeFalsy();
   });
 
   it('should match when call is false', () => {
@@ -30,7 +34,56 @@ describe('call condition', () => {
     // With no state.call published, the bare condition matches `false`,
     // so `call: false` is satisfied.
     expect(evaluator.evaluate({}).result).toBeTruthy();
-    expect(evaluator.evaluate({ call: true }).result).toBeFalsy();
-    expect(evaluator.evaluate({ call: false }).result).toBeTruthy();
+    expect(
+      evaluator.evaluate({ call: { active: true, answered: false } }).result,
+    ).toBeFalsy();
+    expect(
+      evaluator.evaluate({ call: { active: false, answered: false } }).result,
+    ).toBeTruthy();
+  });
+
+  it('should additionally match on answered when specified', () => {
+    const evaluator = createConditionEvaluator(
+      { condition: 'call' as const, call: true, answered: true },
+      createEvaluatorContext(),
+    );
+
+    expect(
+      evaluator.evaluate({ call: { active: true, answered: true } }).result,
+    ).toBeTruthy();
+    expect(
+      evaluator.evaluate({ call: { active: true, answered: false } }).result,
+    ).toBeFalsy();
+    expect(
+      evaluator.evaluate({ call: { active: false, answered: true } }).result,
+    ).toBeFalsy();
+  });
+
+  it('should treat absent call state as inactive and unanswered when answered is specified', () => {
+    const evaluator = createConditionEvaluator(
+      { condition: 'call' as const, call: false, answered: false },
+      createEvaluatorContext(),
+    );
+
+    expect(evaluator.evaluate({}).result).toBeTruthy();
+  });
+
+  it('should match ended-while-unanswered (rejected) distinctly from ended-after-answered', () => {
+    const rejected = createConditionEvaluator(
+      { condition: 'call' as const, call: false, answered: false },
+      createEvaluatorContext(),
+    );
+    const hungUp = createConditionEvaluator(
+      { condition: 'call' as const, call: false, answered: true },
+      createEvaluatorContext(),
+    );
+
+    const endedUnanswered = { call: { active: false, answered: false } };
+    const endedAnswered = { call: { active: false, answered: true } };
+
+    expect(rejected.evaluate(endedUnanswered).result).toBeTruthy();
+    expect(rejected.evaluate(endedAnswered).result).toBeFalsy();
+    expect(hungUp.evaluate(endedUnanswered).result).toBeFalsy();
+    expect(hungUp.evaluate(endedAnswered).result).toBeTruthy();
   });
 });

--- a/tests/condition-trigger/triggers/triggers/call.test.ts
+++ b/tests/condition-trigger/triggers/triggers/call.test.ts
@@ -22,27 +22,67 @@ describe('CallTrigger', () => {
     const { stateManager, callback } = create({ trigger: 'call' });
 
     // Absent (undefined) is equivalent to false, so this is not a change.
-    stateManager.setState({ call: false });
+    stateManager.setState({ call: { active: false, answered: false } });
     expect(callback).not.toHaveBeenCalled();
 
-    stateManager.setState({ call: true });
+    stateManager.setState({ call: { active: true, answered: false } });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it('should trigger only on changes to the given value', () => {
     const { stateManager, callback } = create({ trigger: 'call', call: true });
-    stateManager.setState({ call: true });
-    stateManager.setState({ call: false });
+    stateManager.setState({ call: { active: true, answered: false } });
+    stateManager.setState({ call: { active: false, answered: false } });
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
   it('should trigger on the falling edge to a false value', () => {
     const { stateManager, callback } = create({ trigger: 'call', call: false });
 
-    stateManager.setState({ call: true });
+    stateManager.setState({ call: { active: true, answered: false } });
     expect(callback).not.toHaveBeenCalled();
 
-    stateManager.setState({ call: false });
+    stateManager.setState({ call: { active: false, answered: false } });
     expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not fire on an answer when the trigger does not care about answered', () => {
+    const { stateManager, callback } = create({ trigger: 'call', call: true });
+
+    stateManager.setState({ call: { active: true, answered: false } });
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    // The call is answered mid-call -- `active` doesn't change, so a plain
+    // `call: true` trigger (no `answered`) must not fire again.
+    stateManager.setState({ call: { active: true, answered: true } });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fire on the answer transition when answered is specified', () => {
+    const { stateManager, callback } = create({
+      trigger: 'call',
+      call: true,
+      answered: true,
+    });
+
+    stateManager.setState({ call: { active: true, answered: false } });
+    expect(callback).not.toHaveBeenCalled();
+
+    stateManager.setState({ call: { active: true, answered: true } });
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should distinguish rejected (ended unanswered) from ended-after-answered', () => {
+    const rejected = create({ trigger: 'call', call: false, answered: false });
+    const hungUp = create({ trigger: 'call', call: false, answered: true });
+
+    rejected.stateManager.setState({ call: { active: true, answered: false } });
+    hungUp.stateManager.setState({ call: { active: true, answered: false } });
+
+    rejected.stateManager.setState({ call: { active: false, answered: false } });
+    hungUp.stateManager.setState({ call: { active: false, answered: false } });
+
+    expect(rejected.callback).toHaveBeenCalledTimes(1);
+    expect(hungUp.callback).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This was completely vibe-coded with Claude Sonnet 5, but it works. Code changes seem reasonable to me, but feel free to just ignore and do it yourself otherwise.

Closes #2566