### PR TITLE
fix: guard getComputedStyle in getTextDirection for disconnected elements (#2410)

### DIFF
--- a/src/utils/text-direction.ts
+++ b/src/utils/text-direction.ts
@@ -1,5 +1,18 @@
 export type TextDirection = 'ltr' | 'rtl';
 
-export const getTextDirection = (element: HTMLElement): TextDirection => {
-  return getComputedStyle(element).direction === 'rtl' ? 'rtl' : 'ltr';
+export const getTextDirection = (
+  element: HTMLElement | null | undefined,
+): TextDirection => {
+  // `element` may be null/undefined, or detached from a document whose view is
+  // no longer live (mobile lifecycle races: tab switch, picture-in-picture,
+  // re-layout). Calling `getComputedStyle` in those states throws, e.g.
+  // "Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of
+  // type 'Element'" (Firefox: "Argument 1 is not an object"). Resolve the view
+  // from the element itself and fall back to the default direction rather than
+  // throwing. Regression guard for #2410 (previously #1909, #1217).
+  const view = element?.ownerDocument.defaultView;
+  if (!element || !view) {
+    return 'ltr';
+  }
+  return view.getComputedStyle(element).direction === 'rtl' ? 'rtl' : 'ltr';
 };

--- a/tests/utils/text-direction.test.ts
+++ b/tests/utils/text-direction.test.ts
@@ -23,4 +23,25 @@ describe('getTextDirection', () => {
 
     expect(getTextDirection(element)).toBe('ltr');
   });
+
+  it('should return ltr for a null element', () => {
+    expect(() => getTextDirection(null)).not.toThrow();
+    expect(getTextDirection(null)).toBe('ltr');
+  });
+
+  it('should return ltr for an undefined element', () => {
+    expect(() => getTextDirection(undefined)).not.toThrow();
+    expect(getTextDirection(undefined)).toBe('ltr');
+  });
+
+  it('should return ltr for an element with no document view', () => {
+    // A document created via `createHTMLDocument` has no browsing context, so
+    // its `defaultView` is null -- mirroring a disconnected element on mobile
+    // whose view has been torn down. `getComputedStyle` would throw here.
+    const element = document.implementation.createHTMLDocument('').createElement('div');
+    element.style.direction = 'rtl';
+
+    expect(() => getTextDirection(element)).not.toThrow();
+    expect(getTextDirection(element)).toBe('ltr');
+  });
 });


### PR DESCRIPTION
## Summary

`getTextDirection()` calls `getComputedStyle(element)` with no guard. The viewer and
live carousels call it as `getTextDirection(this)` from `_renderNextPrevious()` during
`render()`. On mobile, in a transient lifecycle window (tab switch, picture-in-picture,
re-layout) `this` can be disconnected, or its document's view torn down, so the call
throws and floods the HA log:

```
TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'
```

Firefox variant: `Window.getComputedStyle: Argument 1 is not an object`.

Because the zoomer wraps the carousels, the bundled stack shows up in `zoomer-*.js`.

Fixes #2410. This re-surfaces a crash previously fixed as #1909 / #1217; the current
unguarded call site dates to the `text-direction.ts` extraction in #1757.

## Fix

Resolve the view from the element itself (`element.ownerDocument.defaultView`) and fall
back to `'ltr'` when the element or its view is missing, calling `view.getComputedStyle(...)`
so the cross-realm variant is handled too. Behaviour is unchanged for the normal connected
case.

The base `carousel.ts` already skips carousel construction when `!this.isConnected` (#1992),
but the viewer/live callers run inside `render()` and aren't guarded — and `isConnected`
alone wouldn't cover the dead-view / cross-realm cases. Guarding the single utility fixes
all three call sites uniformly.

## Tests

Extended `tests/utils/text-direction.test.ts` (jsdom): rtl, ltr, default, null, undefined,
and an element whose document has no view (`defaultView === null`) — asserting no throw and
the `'ltr'` fallback. `text-direction.ts` stays at 100% coverage.

Locally: lint, format-check, the full test suite, coverage, and the rollup build are all green.
