### PR TITLE
fix: preserve pre-event context for Frigate reviews

### DIFF
--- a/src/camera-manager/frigate/engine-frigate.ts
+++ b/src/camera-manager/frigate/engine-frigate.ts
@@ -905,7 +905,7 @@ export class FrigateCameraManagerEngine
     target: Date,
     engineOptions?: EngineOptions,
   ): Promise<number | null> {
-    const mediaStart = media.getStartTime();
+    const mediaStart = media.getUsableStartTime();
     const mediaEnd = media.getEndTime();
     const cameraID = media.getCameraID();
     const mediaType = media.getMediaType();

--- a/src/camera-manager/frigate/engine-frigate.ts
+++ b/src/camera-manager/frigate/engine-frigate.ts
@@ -905,7 +905,7 @@ export class FrigateCameraManagerEngine
     target: Date,
     engineOptions?: EngineOptions,
   ): Promise<number | null> {
-    const mediaStart = media.getUsableStartTime();
+    const mediaStart = media.getStartTime();
     const mediaEnd = media.getEndTime();
     const cameraID = media.getCameraID();
     const mediaType = media.getMediaType();

--- a/src/camera-manager/frigate/media.ts
+++ b/src/camera-manager/frigate/media.ts
@@ -24,6 +24,10 @@ import {
   getReviewTitle,
 } from './util';
 
+// A review starts at the moment of detection, so playback without padding opens
+// with the subject already in frame. Five seconds matches the padding the
+// Frigate integration applies to event clips:
+// https://github.com/blakeblackshear/frigate-hass-integration/blob/v5.15.4/custom_components/frigate/const.py#L71
 const FRIGATE_REVIEW_PADDING_SECONDS = 5;
 
 export class FrigateEventViewMedia extends ViewMedia implements EventViewMedia {
@@ -176,10 +180,13 @@ export class FrigateReviewViewMedia extends ViewMedia implements ReviewViewMedia
   public getStartTime(): Date {
     return fromUnixTime(this._review.start_time);
   }
-  public getUsableStartTime(): Date {
+  public getPlaybackStartTime(): Date {
     const startTime = this.getStartTime();
     const paddedStartTime = subSeconds(startTime, FRIGATE_REVIEW_PADDING_SECONDS);
     const recordingStartTime = startOfHour(startTime);
+
+    // Frigate stores recordings in one-hour files, so ensure the padding never
+    // reaches back past the start of the hour that contains the review.
     return paddedStartTime < recordingStartTime ? recordingStartTime : paddedStartTime;
   }
   public getEndTime(): Date | null {

--- a/src/camera-manager/frigate/media.ts
+++ b/src/camera-manager/frigate/media.ts
@@ -1,4 +1,4 @@
-import { fromUnixTime } from 'date-fns';
+import { fromUnixTime, startOfHour, subSeconds } from 'date-fns';
 import { isEqual } from 'lodash-es';
 
 import type { CameraConfig } from '../../config/schema/cameras';
@@ -23,6 +23,8 @@ import {
   getReviewThumbnailURL,
   getReviewTitle,
 } from './util';
+
+const FRIGATE_REVIEW_PADDING_SECONDS = 5;
 
 export class FrigateEventViewMedia extends ViewMedia implements EventViewMedia {
   private _event: FrigateEvent;
@@ -173,6 +175,12 @@ export class FrigateReviewViewMedia extends ViewMedia implements ReviewViewMedia
   }
   public getStartTime(): Date {
     return fromUnixTime(this._review.start_time);
+  }
+  public getUsableStartTime(): Date {
+    const startTime = this.getStartTime();
+    const paddedStartTime = subSeconds(startTime, FRIGATE_REVIEW_PADDING_SECONDS);
+    const recordingStartTime = startOfHour(startTime);
+    return paddedStartTime < recordingStartTime ? recordingStartTime : paddedStartTime;
   }
   public getEndTime(): Date | null {
     return this._review.end_time ? fromUnixTime(this._review.end_time) : null;

--- a/src/camera-manager/manager.ts
+++ b/src/camera-manager/manager.ts
@@ -747,7 +747,7 @@ export class CameraManager {
   }
 
   public async getMediaSeekTime(media: ViewMedia, target: Date): Promise<number | null> {
-    const startTime = media.getStartTime();
+    const startTime = media.getUsableStartTime();
     const endTime = media.getEndTime();
     const engine = this._store.getEngineForMedia(media);
     const hass = this._api.getHASSManager().getHASS();

--- a/src/camera-manager/manager.ts
+++ b/src/camera-manager/manager.ts
@@ -747,7 +747,7 @@ export class CameraManager {
   }
 
   public async getMediaSeekTime(media: ViewMedia, target: Date): Promise<number | null> {
-    const startTime = media.getUsableStartTime();
+    const startTime = media.getPlaybackStartTime();
     const endTime = media.getEndTime();
     const engine = this._store.getEngineForMedia(media);
     const hass = this._api.getHASSManager().getHASS();

--- a/src/components/viewer/carousel.ts
+++ b/src/components/viewer/carousel.ts
@@ -445,18 +445,26 @@ export class AdvancedCameraCardViewerCarousel extends LitElement {
     }
 
     const view = this.viewManagerEpoch?.manager.getView();
-    const seek = view?.context?.mediaViewer?.seek ?? selectedMedia.getUsableStartTime();
+    const requestedSeek = view?.context?.mediaViewer?.seek ?? null;
+    const seek = requestedSeek ?? selectedMedia.getPlaybackStartTime();
 
     if (!seek) {
       return;
     }
 
-    const seekTimeInMedia = selectedMedia.includesTime(seek);
+    // The media supplies its own playback start time (via
+    // `getPlaybackStartTime()`). Only a seek time set on the view can be
+    // considered falling outside the media.
+    const seekTimeInMedia = !requestedSeek || selectedMedia.includesTime(requestedSeek);
     this.toggleAttribute('unseekable', !seekTimeInMedia);
     if (!seekTimeInMedia && !mediaPlayerController.playback?.isPaused()) {
       void mediaPlayerController.playback?.pause();
     } else if (seekTimeInMedia && mediaPlayerController.playback?.isPaused()) {
       void mediaPlayerController.playback?.play();
+    }
+
+    if (!seekTimeInMedia) {
+      return;
     }
 
     const seekTime =

--- a/src/components/viewer/carousel.ts
+++ b/src/components/viewer/carousel.ts
@@ -445,7 +445,7 @@ export class AdvancedCameraCardViewerCarousel extends LitElement {
     }
 
     const view = this.viewManagerEpoch?.manager.getView();
-    const seek = view?.context?.mediaViewer?.seek ?? selectedMedia.getStartTime();
+    const seek = view?.context?.mediaViewer?.seek ?? selectedMedia.getUsableStartTime();
 
     if (!seek) {
       return;

--- a/src/view/item.ts
+++ b/src/view/item.ts
@@ -42,6 +42,9 @@ export class ViewMedia {
   public getStartTime(): Date | null {
     return null;
   }
+  public getUsableStartTime(): Date | null {
+    return this.getStartTime();
+  }
   public getEndTime(): Date | null {
     return null;
   }
@@ -73,7 +76,7 @@ export class ViewMedia {
     return null;
   }
   public includesTime(seek: Date): boolean {
-    const startTime = this.getStartTime();
+    const startTime = this.getUsableStartTime();
     const endTime = this.getUsableEndTime();
     return !!startTime && !!endTime && seek >= startTime && seek <= endTime;
   }

--- a/src/view/item.ts
+++ b/src/view/item.ts
@@ -42,7 +42,7 @@ export class ViewMedia {
   public getStartTime(): Date | null {
     return null;
   }
-  public getUsableStartTime(): Date | null {
+  public getPlaybackStartTime(): Date | null {
     return this.getStartTime();
   }
   public getEndTime(): Date | null {
@@ -76,7 +76,7 @@ export class ViewMedia {
     return null;
   }
   public includesTime(seek: Date): boolean {
-    const startTime = this.getUsableStartTime();
+    const startTime = this.getStartTime();
     const endTime = this.getUsableEndTime();
     return !!startTime && !!endTime && seek >= startTime && seek <= endTime;
   }

--- a/tests/camera-manager/frigate/engine-frigate.test.ts
+++ b/tests/camera-manager/frigate/engine-frigate.test.ts
@@ -2157,6 +2157,43 @@ describe('FrigateCameraManagerEngine', () => {
       expect(seekTime).toBe(15 * 60);
     });
 
+    it('should get seek time for padded Frigate review media', async () => {
+      const config = createCameraConfig({
+        frigate: { camera_name: 'camera-1', client_id: 'client-1' },
+      });
+      const store = createStore([{ cameraID: 'camera-1', config }]);
+
+      const startTime = new Date('2026-03-14T20:15:00Z');
+      const media = new FrigateReviewViewMedia(
+        'camera-1',
+        createFrigateReview({
+          camera: 'camera-1',
+          start_time: startTime.getTime() / 1000,
+          end_time: new Date('2026-03-14T20:45:00Z').getTime() / 1000,
+        }),
+        'content-id',
+        'thumbnail',
+      );
+
+      vi.mocked(getRecordingSegments).mockResolvedValue([
+        {
+          start_time: new Date('2026-03-14T20:00:00Z').getTime() / 1000,
+          end_time: new Date('2026-03-14T21:00:00Z').getTime() / 1000,
+          id: 'segment-1',
+        },
+      ]);
+
+      const seekTime = await createEngine().getMediaSeekTime(
+        createHASS(),
+        store,
+        media,
+        media.getUsableStartTime(),
+      );
+
+      // Five seconds of context before the review starts at 15 minutes.
+      expect(seekTime).toBe(15 * 60 - 5);
+    });
+
     it('should get zero seek time for clip media when seeking to start', async () => {
       const config = createCameraConfig({
         frigate: { camera_name: 'camera-1', client_id: 'client-1' },

--- a/tests/camera-manager/frigate/engine-frigate.test.ts
+++ b/tests/camera-manager/frigate/engine-frigate.test.ts
@@ -2163,13 +2163,13 @@ describe('FrigateCameraManagerEngine', () => {
       });
       const store = createStore([{ cameraID: 'camera-1', config }]);
 
-      const startTime = new Date('2026-03-14T20:15:00Z');
+      const startTime = new Date('2026-03-14T20:15:00');
       const media = new FrigateReviewViewMedia(
         'camera-1',
         createFrigateReview({
           camera: 'camera-1',
           start_time: startTime.getTime() / 1000,
-          end_time: new Date('2026-03-14T20:45:00Z').getTime() / 1000,
+          end_time: new Date('2026-03-14T20:45:00').getTime() / 1000,
         }),
         'content-id',
         'thumbnail',
@@ -2177,8 +2177,8 @@ describe('FrigateCameraManagerEngine', () => {
 
       vi.mocked(getRecordingSegments).mockResolvedValue([
         {
-          start_time: new Date('2026-03-14T20:00:00Z').getTime() / 1000,
-          end_time: new Date('2026-03-14T21:00:00Z').getTime() / 1000,
+          start_time: new Date('2026-03-14T20:00:00').getTime() / 1000,
+          end_time: new Date('2026-03-14T21:00:00').getTime() / 1000,
           id: 'segment-1',
         },
       ]);
@@ -2187,7 +2187,7 @@ describe('FrigateCameraManagerEngine', () => {
         createHASS(),
         store,
         media,
-        media.getUsableStartTime(),
+        media.getPlaybackStartTime(),
       );
 
       // Five seconds of context before the review starts at 15 minutes.

--- a/tests/camera-manager/frigate/media.test.ts
+++ b/tests/camera-manager/frigate/media.test.ts
@@ -428,20 +428,31 @@ describe('FrigateReviewViewMedia', () => {
 
   it('should include five seconds of pre-review playback', () => {
     const review = createFrigateReview({
-      start_time: new Date('2026-03-14T20:15:00Z').getTime() / 1000,
+      start_time: new Date('2026-03-14T20:15:00').getTime() / 1000,
     });
     const media = new FrigateReviewViewMedia('camera', review, 'content_id', 'thumb');
 
-    expect(media.getUsableStartTime()).toEqual(new Date('2026-03-14T20:14:55Z'));
+    expect(media.getPlaybackStartTime()).toEqual(new Date('2026-03-14T20:14:55'));
   });
 
   it('should not pad before the start of the review recording hour', () => {
     const review = createFrigateReview({
-      start_time: new Date('2026-03-14T20:00:03Z').getTime() / 1000,
+      start_time: new Date('2026-03-14T20:00:03').getTime() / 1000,
     });
     const media = new FrigateReviewViewMedia('camera', review, 'content_id', 'thumb');
 
-    expect(media.getUsableStartTime()).toEqual(new Date('2026-03-14T20:00:00Z'));
+    expect(media.getPlaybackStartTime()).toEqual(new Date('2026-03-14T20:00:00'));
+  });
+
+  it('should not include a time before the review starts', () => {
+    const review = createFrigateReview({
+      start_time: new Date('2026-03-14T20:15:00').getTime() / 1000,
+      end_time: new Date('2026-03-14T20:45:00').getTime() / 1000,
+    });
+    const media = new FrigateReviewViewMedia('camera', review, 'content_id', 'thumb');
+
+    expect(media.includesTime(new Date('2026-03-14T20:15:00'))).toBeTruthy();
+    expect(media.includesTime(new Date('2026-03-14T20:14:56'))).toBeFalsy();
   });
 
   it('should get end time', () => {

--- a/tests/camera-manager/frigate/media.test.ts
+++ b/tests/camera-manager/frigate/media.test.ts
@@ -426,6 +426,24 @@ describe('FrigateReviewViewMedia', () => {
     expect(media.getStartTime()).toEqual(new Date(1683395000 * 1000));
   });
 
+  it('should include five seconds of pre-review playback', () => {
+    const review = createFrigateReview({
+      start_time: new Date('2026-03-14T20:15:00Z').getTime() / 1000,
+    });
+    const media = new FrigateReviewViewMedia('camera', review, 'content_id', 'thumb');
+
+    expect(media.getUsableStartTime()).toEqual(new Date('2026-03-14T20:14:55Z'));
+  });
+
+  it('should not pad before the start of the review recording hour', () => {
+    const review = createFrigateReview({
+      start_time: new Date('2026-03-14T20:00:03Z').getTime() / 1000,
+    });
+    const media = new FrigateReviewViewMedia('camera', review, 'content_id', 'thumb');
+
+    expect(media.getUsableStartTime()).toEqual(new Date('2026-03-14T20:00:00Z'));
+  });
+
   it('should get end time', () => {
     const review = createFrigateReview({
       end_time: 1683397124,

--- a/tests/view/item.test.ts
+++ b/tests/view/item.test.ts
@@ -17,6 +17,7 @@ describe('ViewMedia', () => {
     expect(media.getMediaType()).toBe('clip');
     expect(media.getID()).toBeNull();
     expect(media.getStartTime()).toBeNull();
+    expect(media.getUsableStartTime()).toBeNull();
     expect(media.getEndTime()).toBeNull();
     expect(media.getUsableEndTime()).toBeNull();
     expect(media.inProgress()).toBeNull();
@@ -59,6 +60,13 @@ describe('ViewMedia', () => {
     });
     expect(media.includesTime(new Date('2023-08-08T17:30:30'))).toBeTruthy();
     expect(media.includesTime(new Date('2023-08-08T18:00:00'))).toBeFalsy();
+  });
+
+  it('should use the media start time as the usable start time by default', () => {
+    const startTime = new Date('2023-08-08T17:00:00');
+    const media = new TestViewMedia({ startTime });
+
+    expect(media.getUsableStartTime()).toEqual(startTime);
   });
 
   it('should correctly get usable end time for in-progress event', () => {

--- a/tests/view/item.test.ts
+++ b/tests/view/item.test.ts
@@ -17,7 +17,7 @@ describe('ViewMedia', () => {
     expect(media.getMediaType()).toBe('clip');
     expect(media.getID()).toBeNull();
     expect(media.getStartTime()).toBeNull();
-    expect(media.getUsableStartTime()).toBeNull();
+    expect(media.getPlaybackStartTime()).toBeNull();
     expect(media.getEndTime()).toBeNull();
     expect(media.getUsableEndTime()).toBeNull();
     expect(media.inProgress()).toBeNull();
@@ -62,11 +62,11 @@ describe('ViewMedia', () => {
     expect(media.includesTime(new Date('2023-08-08T18:00:00'))).toBeFalsy();
   });
 
-  it('should use the media start time as the usable start time by default', () => {
+  it('should use the media start time as the playback start time by default', () => {
     const startTime = new Date('2023-08-08T17:00:00');
     const media = new TestViewMedia({ startTime });
 
-    expect(media.getUsableStartTime()).toEqual(startTime);
+    expect(media.getPlaybackStartTime()).toEqual(startTime);
   });
 
   it('should correctly get usable end time for in-progress event', () => {


### PR DESCRIPTION
## Summary

- add a usable playback start time without changing a review's logical event time
- start Frigate review playback five seconds before the review, clamped to the hour recording boundary
- use that playback boundary for automatic viewer seeks and seek validation

This restores the pre-event context that is lost when `media.type: auto` selects native Frigate reviews instead of clips.

Fixes #2743

## Testing

- 198 focused unit tests passed
- `tsc --noEmit -p tsconfig.json`
- ESLint on all changed source and test files