### PR TITLE
fix: Size thumbnail details against the thumbnail, not the viewport

### DIFF
--- a/src/scss/thumbnail-details.scss
+++ b/src/scss/thumbnail-details.scss
@@ -31,12 +31,17 @@ div {
   align-items: center;
   gap: 5px;
 
-  container-type: normal;
-  font-size: 0.95cqh;
+  // `cqh` resolves against the nearest ancestor with `container-type: size`.
+  // `normal` explicitly makes this element *not* a container and nothing else in
+  // the card establishes one, so these lengths fell back to the viewport: text
+  // shrank to a few pixels in a narrow carousel and grew unbounded on large
+  // displays. Size against the thumbnail itself, which is what the container
+  // units were reaching for.
+  font-size: calc(var(--advanced-camera-card-thumbnail-size) * 0.152);
 
   &.heading {
     font-weight: bold;
-    font-size: 1cqh;
+    font-size: calc(var(--advanced-camera-card-thumbnail-size) * 0.16);
   }
 
   span {

--- a/src/scss/thumbnail-details.scss
+++ b/src/scss/thumbnail-details.scss
@@ -21,7 +21,14 @@
 
   overflow: hidden;
 
-  --mdc-icon-size: 16px;
+  // Match the body text of the dashboard the card sits on, including any font
+  // scaling the user has set there. This is also the basis each row's `em`
+  // resolves against.
+  font-size: var(--ha-font-size-m, 14px);
+
+  // Pin the line height the rows inherit, so a Home Assistant change cannot
+  // alter how many details fit in the panel.
+  line-height: normal;
 }
 
 div {
@@ -31,17 +38,16 @@ div {
   align-items: center;
   gap: 5px;
 
-  // `cqh` resolves against the nearest ancestor with `container-type: size`.
-  // `normal` explicitly makes this element *not* a container and nothing else in
-  // the card establishes one, so these lengths fell back to the viewport: text
-  // shrank to a few pixels in a narrow carousel and grew unbounded on large
-  // displays. Size against the thumbnail itself, which is what the container
-  // units were reaching for.
-  font-size: calc(var(--advanced-camera-card-thumbnail-size) * 0.152);
+  // Icons match the text on their own row, so this belongs on the rows rather
+  // than on `:host`.
+  --mdc-icon-size: 1em;
+
+  &:not(.heading) {
+    font-size: 0.8em;
+  }
 
   &.heading {
     font-weight: bold;
-    font-size: calc(var(--advanced-camera-card-thumbnail-size) * 0.16);
   }
 
   span {

--- a/tests/browser/style.ts
+++ b/tests/browser/style.ts
@@ -5,6 +5,8 @@
 const HOME_ASSISTANT_THEME = `
   html {
     --ha-font-family-body: Roboto, Noto, sans-serif;
+    --ha-font-size-scale: 1;
+    --ha-font-size-m: calc(14px * var(--ha-font-size-scale));
 
     --primary-text-color: #141414;
     --secondary-text-color: #5e5e5e;

--- a/tests/components/thumbnail/details.browser.test.ts
+++ b/tests/components/thumbnail/details.browser.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, assert, describe, expect, it } from 'vitest';
+
+import {
+  THUMBNAIL_WIDTH_DEFAULT,
+  THUMBNAIL_WIDTH_MAX,
+  THUMBNAIL_WIDTH_MIN,
+} from '../../../src/config/schema/common/controls/thumbnails';
+import { deepQuery, deepQueryAll } from '../../browser/dom';
+import {
+  createTestFrigateEvent,
+  EVENT_TIME_NEWER,
+  mountCardWithFrigate,
+} from '../../browser/fake-frigate';
+import type { MountedCard } from '../../browser/mounted-card';
+import { waitForThumbnails } from '../../browser/test-utils';
+
+const mountGalleryWithThumbnailSize = async (size: number): Promise<MountedCard> => {
+  const { card } = await mountCardWithFrigate(
+    [createTestFrigateEvent('event', EVENT_TIME_NEWER)],
+    {
+      view: { default: 'clips' },
+      media_gallery: { controls: { thumbnails: { size, show_details: true } } },
+    },
+  );
+  await waitForThumbnails(card, 1);
+  return card;
+};
+
+const getDetails = (card: MountedCard): Element => {
+  const details = deepQuery(card.card, 'advanced-camera-card-thumbnail-details');
+  assert(details);
+  return details;
+};
+
+const getHeading = (details: Element): Element => {
+  const heading = deepQuery(details, 'div.heading');
+  assert(heading);
+  return heading;
+};
+
+const getMetadataRow = (details: Element): Element => {
+  const row = deepQueryAll(details, 'div').find(
+    (div) => !div.classList.contains('heading'),
+  );
+  assert(row);
+  return row;
+};
+
+const getFontSize = (element: Element): number =>
+  parseFloat(getComputedStyle(element).fontSize);
+
+// Compare within 1/10th of a pixel.
+const PIXEL_PRECISION = 1;
+
+const HEADING_SIZE = 14;
+const METADATA_RATIO = 0.8;
+
+describe('AdvancedCameraCardThumbnailDetails', () => {
+  afterEach(() => {
+    document.body.style.removeProperty('line-height');
+    document.documentElement.style.removeProperty('--ha-font-size-scale');
+  });
+
+  it('should size the heading independently of the thumbnail size', async () => {
+    const smallest = await mountGalleryWithThumbnailSize(THUMBNAIL_WIDTH_MIN);
+    expect(getFontSize(getHeading(getDetails(smallest)))).toBeCloseTo(
+      HEADING_SIZE,
+      PIXEL_PRECISION,
+    );
+
+    const largest = await mountGalleryWithThumbnailSize(THUMBNAIL_WIDTH_MAX);
+    expect(getFontSize(getHeading(getDetails(largest)))).toBeCloseTo(
+      HEADING_SIZE,
+      PIXEL_PRECISION,
+    );
+  });
+
+  it('should follow the font scaling the dashboard is set to', async () => {
+    document.documentElement.style.setProperty('--ha-font-size-scale', '2');
+
+    const card = await mountGalleryWithThumbnailSize(THUMBNAIL_WIDTH_DEFAULT);
+
+    expect(getFontSize(getHeading(getDetails(card)))).toBeCloseTo(
+      HEADING_SIZE * 2,
+      PIXEL_PRECISION,
+    );
+  });
+
+  it('should make the metadata text smaller than the heading', async () => {
+    const card = await mountGalleryWithThumbnailSize(THUMBNAIL_WIDTH_DEFAULT);
+    const details = getDetails(card);
+
+    expect(getFontSize(getMetadataRow(details))).toBeCloseTo(
+      getFontSize(getHeading(details)) * METADATA_RATIO,
+      PIXEL_PRECISION,
+    );
+  });
+
+  it('should size each icon to match the text beside it', async () => {
+    const card = await mountGalleryWithThumbnailSize(THUMBNAIL_WIDTH_DEFAULT);
+    const row = getMetadataRow(getDetails(card));
+
+    const icon = deepQuery(row, 'advanced-camera-card-icon');
+    assert(icon);
+
+    expect(parseFloat(getComputedStyle(icon).width)).toBeCloseTo(
+      getFontSize(row),
+      PIXEL_PRECISION,
+    );
+  });
+
+  it('should ignore a line height inherited from the page', async () => {
+    document.body.style.setProperty('line-height', '3');
+
+    const card = await mountGalleryWithThumbnailSize(THUMBNAIL_WIDTH_DEFAULT);
+
+    expect(getComputedStyle(getHeading(getDetails(card))).lineHeight).toBe('normal');
+  });
+});


### PR DESCRIPTION
Fixes the first half of #2750.

### Problem

`src/scss/thumbnail-details.scss` sizes detail text in `cqh` while declaring
`container-type: normal` on the same element. `normal` is the initial value and
explicitly means "not a query container", and it is the only `container-type`
declaration anywhere in `src/scss`, so no ancestor establishes one either.

With no eligible query container, [container query length units resolve against
the small viewport](https://drafts.csswg.org/css-contain-3/#container-query-length).
`1cqh` is therefore 1% of the *window* height rather than 1% of the thumbnail --
about 10px at 1080p, less on a laptop or phone, and unbounded on a 4K display.
In a narrow `mode: left` carousel at `size: 100` the text is effectively
unreadable. Before `8.0.0` the heading was a fixed `1.2rem`.

### Why not just add a container

Making the declared intent work -- `container-type: size` on `:host`, whose
`max-height` is already `var(--advanced-camera-card-thumbnail-size)` -- makes
things worse, not better: `1cqh` of a 100px panel is 1px. The units and the
chosen values are inconsistent with one another, so the fix has to pick a basis
rather than just establish a container.

### Change

Anchor both sizes to `--advanced-camera-card-thumbnail-size`, which is what the
container units were reaching for and is already the basis for the panel's
`max-height`. The multipliers preserve the 0.95:1 detail-to-heading ratio the
`cqh` values expressed, and land on 15.2px/16px at the default `size: 100`.

The multipliers are a judgement call and I'd happily change them to whatever you
prefer -- the substantive part of this PR is dropping the viewport dependency.

### Not addressed here

The second symptom in #2750 -- the event heading wrapping out of view at small
thumbnail sizes, because `:host` caps `max-height` at the thumbnail size -- is
left alone, since the right behaviour there is a design decision rather than a
mechanical fix.

### Testing

- `prettier --check` passes on the changed file.
- CSS-only change; no test or documentation surface is affected.
